### PR TITLE
[S] feat: Claude Code connector — local hooks, no tunnel needed

### DIFF
--- a/IslandAppLib/Views/Settings/SettingsView.swift
+++ b/IslandAppLib/Views/Settings/SettingsView.swift
@@ -42,7 +42,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Settings")
                 .font(.system(size: 22, weight: .semibold))
-            Text("Configure your Manus connection and app preferences.")
+            Text("Configure your agent connections and app preferences.")
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
         }
@@ -71,7 +71,7 @@ private struct ConnectedServicesSection: View {
             VStack(spacing: 0) {
                 ManusServiceRow(store: store)
                 rowDivider
-                ComingSoonRow(name: "Claude Code", subtitle: "Local agent integration")
+                ClaudeCodeServiceRow()
                 rowDivider
                 ComingSoonRow(name: "Cursor", subtitle: "Editor-side task ingestion")
             }
@@ -216,6 +216,74 @@ private struct ManusServiceRow: View {
             return "Network unavailable. Check your connection and retry."
         }
         return "Couldn't connect: \(raw)"
+    }
+}
+
+// MARK: - Claude Code row
+
+/// Enables/disables the Claude Code integration by installing hook entries
+/// into `~/.claude/settings.json` (via `ClaudeHooksInstaller`). Sessions
+/// report their lifecycle to the always-running `LocalHookServer` — no API
+/// key, no tunnel.
+private struct ClaudeCodeServiceRow: View {
+    @State private var isInstalled = ClaudeHooksInstaller.isInstalled()
+    @State private var lastError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(isInstalled ? Color.green : Color.secondary.opacity(0.5))
+                    .frame(width: 8, height: 8)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Claude Code").font(.system(size: 13, weight: .semibold))
+                    Text(isInstalled
+                         ? "Hooks installed — sessions report status live"
+                         : "Track local Claude Code sessions in the island")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isInstalled {
+                    Button("Disable", role: .destructive) { uninstall() }
+                } else {
+                    Button("Enable") { install() }
+                }
+            }
+
+            if isInstalled {
+                Text("Applies to Claude Code sessions started after enabling.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            if let lastError {
+                Text(lastError)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.red)
+            }
+        }
+        .padding(16)
+    }
+
+    private func install() {
+        do {
+            try ClaudeHooksInstaller.install()
+            isInstalled = true
+            lastError = nil
+        } catch {
+            lastError = "Couldn't update ~/.claude/settings.json: \(error.localizedDescription)"
+        }
+    }
+
+    private func uninstall() {
+        do {
+            try ClaudeHooksInstaller.uninstall()
+            isInstalled = false
+            lastError = nil
+        } catch {
+            lastError = "Couldn't update ~/.claude/settings.json: \(error.localizedDescription)"
+        }
     }
 }
 

--- a/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeCodeConnector.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeCodeConnector.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Tracks local Claude Code sessions as `AgentTask`s.
+///
+/// Unlike `ManusConnector` there is no remote API: state is event-sourced
+/// from hook callbacks delivered by `LocalHookServer`. Each session becomes
+/// one task; the task's `taskURL` is a `file://` URL of the project
+/// directory so "open" lands in Finder.
+///
+/// Status mapping:
+///   SessionStart / UserPromptSubmit          → .running
+///   Notification (permission/idle/input/…)   → .waiting
+///   Notification (agent_completed)           → .completed
+///   Stop                                      → .completed
+///   StopFailure                               → .failed
+///   SessionEnd                                → session removed
+public actor ClaudeCodeConnector: AgentConnector {
+    public let source = "claude-code"
+
+    /// Notification subtypes that mean "the agent is blocked on the user".
+    static let waitingNotificationTypes: Set<String> = [
+        "permission_prompt", "idle_prompt", "agent_needs_input", "elicitation_dialog",
+    ]
+    /// Notification subtypes that carry no actionable state change.
+    static let ignoredNotificationTypes: Set<String> = [
+        "auth_success", "elicitation_complete", "elicitation_response",
+    ]
+
+    /// Finished sessions linger briefly so the user sees the green state,
+    /// then get pruned. Sessions that stop emitting events entirely (e.g.
+    /// Claude Code crashed before SessionEnd) are dropped after a day.
+    static let finishedTTL: TimeInterval = 2 * 60 * 60
+    static let staleTTL: TimeInterval = 24 * 60 * 60
+
+    private var sessions: [String: AgentTask] = [:]
+
+    public init() {}
+
+    // MARK: - AgentConnector
+
+    public func fetchTasks() async throws -> [AgentTask] {
+        snapshot()
+    }
+
+    nonisolated public func openInBrowser(taskId: String) {
+        // URL opening is handled by TaskStore.openTaskInBrowser(id:).
+    }
+
+    public func stop(taskId: String) async throws {
+        // Local sessions can't be stopped remotely — no-op by design.
+    }
+
+    // MARK: - Event ingestion
+
+    /// Apply one hook event and return the updated task snapshot.
+    public func apply(_ event: ClaudeCodeEvent, now: Date = .now) -> [AgentTask] {
+        prune(now: now)
+
+        switch event.hookEventName {
+        case .sessionStart, .userPromptSubmit:
+            upsert(event, now: now) { task in
+                task.status = .running
+                task.currentPhase = nil
+                task.waitingMessage = nil
+            }
+
+        case .notification:
+            applyNotification(event, now: now)
+
+        case .stop:
+            upsert(event, now: now) { task in
+                task.status = .completed
+                task.currentPhase = nil
+                task.waitingMessage = nil
+            }
+
+        case .stopFailure:
+            upsert(event, now: now) { task in
+                task.status = .failed
+                task.currentPhase = "Turn ended with an API error"
+                task.waitingMessage = nil
+            }
+
+        case .sessionEnd:
+            sessions.removeValue(forKey: event.sessionId)
+        }
+
+        return snapshot()
+    }
+
+    // MARK: - Private
+
+    private func applyNotification(_ event: ClaudeCodeEvent, now: Date) {
+        let type = event.notificationType
+
+        if let type, Self.ignoredNotificationTypes.contains(type) {
+            return
+        }
+        if type == "agent_completed" {
+            upsert(event, now: now) { task in
+                task.status = .completed
+                task.currentPhase = nil
+                task.waitingMessage = nil
+            }
+            return
+        }
+        // Known waiting subtypes — and, defensively, any unknown/missing
+        // subtype: a notification generally means Claude wants attention.
+        upsert(event, now: now) { task in
+            task.status = .waiting
+            task.currentPhase = "Needs input"
+            task.waitingMessage = event.message
+        }
+    }
+
+    private func upsert(_ event: ClaudeCodeEvent, now: Date, mutate: (inout AgentTask) -> Void) {
+        var task = sessions[event.sessionId] ?? Self.newTask(for: event, now: now)
+        mutate(&task)
+        task.updatedAt = now
+        sessions[event.sessionId] = task
+    }
+
+    private static func newTask(for event: ClaudeCodeEvent, now: Date) -> AgentTask {
+        let projectURL = event.cwd.map { URL(fileURLWithPath: $0, isDirectory: true) }
+        return AgentTask(
+            id: event.sessionId,
+            source: "claude-code",
+            title: projectURL?.lastPathComponent ?? "Claude Code session",
+            status: .running,
+            createdAt: now,
+            updatedAt: now,
+            taskURL: projectURL?.absoluteString ?? ""
+        )
+    }
+
+    private func prune(now: Date) {
+        sessions = sessions.filter { _, task in
+            let age = now.timeIntervalSince(task.updatedAt)
+            switch task.status {
+            case .completed, .failed: return age < Self.finishedTTL
+            case .running, .waiting:  return age < Self.staleTTL
+            }
+        }
+    }
+
+    private func snapshot() -> [AgentTask] {
+        sessions.values.sorted { $0.createdAt < $1.createdAt }
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeCodeEvent.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeCodeEvent.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One lifecycle event emitted by a Claude Code hook.
+///
+/// Claude Code invokes our hook command (a `curl` one-liner installed into
+/// `~/.claude/settings.json`) and pipes a JSON payload on stdin, which the
+/// hook forwards verbatim to `LocalHookServer`. Field names are snake_case
+/// (`session_id`, `hook_event_name`, …) — decode with `.convertFromSnakeCase`.
+///
+/// Only the events we install hooks for are modeled. Anything else fails to
+/// decode and is dropped by the server without disturbing Claude Code.
+public struct ClaudeCodeEvent: Decodable, Sendable {
+
+    public enum Kind: String, Decodable, Sendable {
+        case sessionStart     = "SessionStart"
+        case userPromptSubmit = "UserPromptSubmit"
+        case notification     = "Notification"
+        case stop             = "Stop"
+        case stopFailure      = "StopFailure"
+        case sessionEnd       = "SessionEnd"
+    }
+
+    public let hookEventName: Kind
+    public let sessionId: String
+    /// Project directory the session runs in. Used for the task title and
+    /// the open-in-Finder URL.
+    public let cwd: String?
+    /// Human-readable text carried by `Notification` events.
+    public let message: String?
+    /// Notification subtype (`permission_prompt`, `idle_prompt`,
+    /// `agent_needs_input`, `auth_success`, …). Missing on older Claude Code
+    /// versions — treat absence as "needs attention".
+    public let notificationType: String?
+
+    public init(
+        hookEventName: Kind,
+        sessionId: String,
+        cwd: String? = nil,
+        message: String? = nil,
+        notificationType: String? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.sessionId = sessionId
+        self.cwd = cwd
+        self.message = message
+        self.notificationType = notificationType
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeHooksInstaller.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeHooksInstaller.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Installs / removes the Dev Island hook entries in Claude Code's user
+/// settings (`~/.claude/settings.json`).
+///
+/// The hook is a `curl` one-liner that forwards the JSON payload Claude Code
+/// pipes on stdin to `LocalHookServer`. It is deliberately fire-and-forget
+/// (`-m 2`, trailing `|| true`) so a stopped or crashed Dev Island can never
+/// block or fail a Claude Code turn.
+///
+/// All edits are merge-based via `JSONSerialization`: existing user hooks,
+/// unknown settings keys, and unrelated hook groups are preserved verbatim.
+/// Our entries are recognized by the `/hooks/claude-code` marker in the
+/// command string, which makes install idempotent and uninstall surgical.
+public enum ClaudeHooksInstaller {
+
+    public static let defaultPort = 7824
+
+    /// Hook events we subscribe to. Keep in sync with `ClaudeCodeEvent.Kind`.
+    static let events = [
+        "SessionStart", "UserPromptSubmit", "Notification",
+        "Stop", "StopFailure", "SessionEnd",
+    ]
+
+    static let endpointPath = "/hooks/claude-code"
+
+    public static func hookCommand(port: Int = defaultPort) -> String {
+        "curl -sf -m 2 -X POST http://127.0.0.1:\(port)\(endpointPath) "
+            + "-H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true"
+    }
+
+    public static var defaultSettingsURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/settings.json")
+    }
+
+    // MARK: - Public API
+
+    public static func isInstalled(settingsURL: URL? = nil) -> Bool {
+        let url = settingsURL ?? defaultSettingsURL
+        guard let root = readSettings(at: url),
+              let hooks = root["hooks"] as? [String: Any] else { return false }
+        // Consider installed when every event we need carries our command.
+        return events.allSatisfy { event in
+            guard let groups = hooks[event] as? [[String: Any]] else { return false }
+            return groups.contains(where: isOurGroup)
+        }
+    }
+
+    public static func install(settingsURL: URL? = nil, port: Int = defaultPort) throws {
+        let url = settingsURL ?? defaultSettingsURL
+        var root = readSettings(at: url) ?? [:]
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+
+        let ourGroup: [String: Any] = [
+            "matcher": "",
+            "hooks": [["type": "command", "command": hookCommand(port: port)]],
+        ]
+
+        for event in events {
+            var groups = hooks[event] as? [[String: Any]] ?? []
+            groups.removeAll(where: isOurGroup)  // drop stale versions of ours
+            groups.append(ourGroup)
+            hooks[event] = groups
+        }
+
+        root["hooks"] = hooks
+        try writeSettings(root, to: url)
+    }
+
+    public static func uninstall(settingsURL: URL? = nil) throws {
+        let url = settingsURL ?? defaultSettingsURL
+        guard var root = readSettings(at: url),
+              var hooks = root["hooks"] as? [String: Any] else { return }
+
+        for (event, value) in hooks {
+            guard var groups = value as? [[String: Any]] else { continue }
+            groups.removeAll(where: isOurGroup)
+            if groups.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = groups
+            }
+        }
+
+        if hooks.isEmpty {
+            root.removeValue(forKey: "hooks")
+        } else {
+            root["hooks"] = hooks
+        }
+        try writeSettings(root, to: url)
+    }
+
+    // MARK: - Private
+
+    /// A matcher group is "ours" when every command in it targets our
+    /// local endpoint (user-authored groups are never all-ours).
+    private static func isOurGroup(_ group: [String: Any]) -> Bool {
+        guard let handlers = group["hooks"] as? [[String: Any]], !handlers.isEmpty else {
+            return false
+        }
+        return handlers.allSatisfy { handler in
+            (handler["command"] as? String)?.contains(endpointPath) == true
+        }
+    }
+
+    private static func readSettings(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func writeSettings(_ root: [String: Any], to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
+++ b/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Hummingbird
+
+/// Localhost-only HTTP server that receives lifecycle events from local
+/// agent CLIs (Claude Code today; Codex is expected to reuse this).
+///
+/// Deliberately separate from `WebhookServer`: that one is exposed to the
+/// public internet through the cloudflared tunnel for Manus, while this one
+/// must never leave 127.0.0.1. No signature verification is needed — the
+/// bind address is the trust boundary.
+///
+/// Always returns 200 (even for undecodable bodies) so a hook misfire can
+/// never surface as an error inside the user's Claude Code session.
+public actor LocalHookServer {
+    public let port: Int
+    private var serverTask: Task<Void, Error>?
+
+    public init(port: Int = ClaudeHooksInstaller.defaultPort) {
+        self.port = port
+    }
+
+    public func start(onClaudeCodeEvent: @escaping @Sendable (ClaudeCodeEvent) -> Void) {
+        serverTask = Task {
+            let router = Router()
+
+            router.post("/hooks/claude-code") { request, _ -> HTTPResponse.Status in
+                var buffer = try await request.body.collect(upTo: 1_048_576)
+                let data = Data(buffer.readableBytesView)
+
+                let decoder = JSONDecoder()
+                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                guard let event = try? decoder.decode(ClaudeCodeEvent.self, from: data) else {
+                    IslandLogger.webhook.debug("Ignoring undecodable Claude Code hook payload")
+                    return .ok
+                }
+
+                IslandLogger.webhook.info(
+                    "Claude Code event: \(event.hookEventName.rawValue) session=\(event.sessionId)")
+                onClaudeCodeEvent(event)
+                return .ok
+            }
+
+            let app = Application(
+                router: router,
+                configuration: .init(address: .hostname("127.0.0.1", port: self.port))
+            )
+            IslandLogger.webhook.info("LocalHookServer listening on 127.0.0.1:\(self.port)")
+            try await app.run()
+        }
+    }
+
+    public func stop() {
+        serverTask?.cancel()
+        serverTask = nil
+        IslandLogger.webhook.info("LocalHookServer stopped")
+    }
+}

--- a/IslandCore/Sources/IslandCore/Sync/StateReconciler.swift
+++ b/IslandCore/Sources/IslandCore/Sync/StateReconciler.swift
@@ -2,6 +2,16 @@ import Foundation
 
 enum StateReconciler {
 
+    /// Merge a remote polling snapshot into local state, touching only tasks
+    /// of the given source. Tasks from other sources (e.g. local "claude-code"
+    /// sessions during a Manus poll) pass through untouched — a remote
+    /// snapshot is only authoritative for its own source.
+    static func reconcile(local: [AgentTask], incoming: [AgentTask], source: String) -> [AgentTask] {
+        let scoped = local.filter { $0.source == source }
+        let others = local.filter { $0.source != source }
+        return reconcile(local: scoped, incoming: incoming) + others
+    }
+
     /// Merge a remote polling snapshot into local state.
     /// Remote is authoritative: tasks present only locally are dropped.
     /// For tasks present in both, take the version with the later updatedAt.

--- a/IslandCore/Sources/IslandCore/TaskStore.swift
+++ b/IslandCore/Sources/IslandCore/TaskStore.swift
@@ -21,6 +21,11 @@ public final class TaskStore {
     private var sqliteStore: SQLiteStore?
     private var pollingOnlyMode = false
 
+    // Local agent pipeline (Claude Code) — independent of the Manus API key
+    // and of the tunnel/polling lifecycle: it runs for the app's lifetime.
+    private var localHookServer: LocalHookServer?
+    private var claudeConnector: ClaudeCodeConnector?
+
     private var sleepObserver: NSObjectProtocol?
     private var wakeObserver: NSObjectProtocol?
 
@@ -52,7 +57,9 @@ public final class TaskStore {
     public func clearAPIKey() {
         stopServices()
         try? KeychainStore.delete()
-        tasks = []
+        // Only Manus tasks belong to the API key — local agent sessions
+        // (Claude Code) are unaffected by a disconnect.
+        tasks = tasks.filter { $0.source != "manus" }
         apiKeyStatus = .notConfigured
         connectionStatus = .disconnected
         IslandLogger.store.info("API key cleared")
@@ -65,7 +72,10 @@ public final class TaskStore {
     }
 
     public func stopTask(id: String) async throws {
-        guard let connector = connectors.first else { return }
+        guard let task = tasks.first(where: { $0.id == id }) else { return }
+        // Only Manus tasks can be stopped remotely; local sessions
+        // (Claude Code) are driven by their own CLI.
+        guard task.source == "manus", let connector = connectors.first else { return }
         try await connector.stop(taskId: id)
         // Optimistically update status
         tasks = tasks.map { t in
@@ -96,15 +106,23 @@ public final class TaskStore {
     }
 
     internal func applyPollingSnapshot(_ incoming: [AgentTask]) {
-        tasks = StateReconciler.reconcile(local: tasks, incoming: incoming)
+        // Polling only covers Manus — scope the reconcile so local agent
+        // sessions (claude-code) survive the snapshot merge.
+        tasks = StateReconciler.reconcile(local: tasks, incoming: incoming, source: "manus")
         let store = sqliteStore
-        let snapshot = tasks
+        let snapshot = tasks.filter { $0.source == "manus" }
         Task.detached {
             guard let store else { return }
             for task in snapshot {
                 try? await store.insertOrReplace(task: task)
             }
         }
+    }
+
+    /// Replace all tasks of one local source with a fresh snapshot from its
+    /// connector (event-sourced, so the connector state is authoritative).
+    internal func applyLocalSnapshot(source: String, _ snapshot: [AgentTask]) {
+        tasks = tasks.filter { $0.source != source } + snapshot
     }
 
     // MARK: - Bootstrap
@@ -114,6 +132,9 @@ public final class TaskStore {
         let store = SQLiteStore()
         try? await store.open()
         sqliteStore = store
+
+        // Local agent pipeline runs regardless of Manus configuration.
+        startLocalHookPipeline()
 
         // Load API key from Keychain
         guard let apiKey = try? KeychainStore.load() else {
@@ -127,7 +148,7 @@ public final class TaskStore {
         do {
             let initialTasks = try await client.listTasks()
             apiKeyStatus = .valid
-            tasks = initialTasks
+            applyPollingSnapshot(initialTasks)
         } catch ManusError.unauthorized {
             apiKeyStatus = .invalid
             IslandLogger.store.warning("Stored API key is invalid")
@@ -145,6 +166,26 @@ public final class TaskStore {
         }
 
         registerSleepWakeObservers()
+    }
+
+    // MARK: - Local agent pipeline (Claude Code)
+
+    private func startLocalHookPipeline() {
+        let connector = ClaudeCodeConnector()
+        claudeConnector = connector
+        let server = LocalHookServer()
+        localHookServer = server
+
+        Task {
+            await server.start { [weak self] event in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    let snapshot = await connector.apply(event)
+                    self.applyLocalSnapshot(source: connector.source, snapshot)
+                }
+            }
+        }
+        IslandLogger.store.info("Local hook pipeline started (claude-code)")
     }
 
     // MARK: - Service lifecycle

--- a/IslandCoreCLI/Sources/IslandCoreCLI/main.swift
+++ b/IslandCoreCLI/Sources/IslandCoreCLI/main.swift
@@ -2,15 +2,48 @@ import Foundation
 import IslandCore
 
 // MARK: - CLI Integration Test Tool
-// Usage: MANUS_API_KEY_DEV=mk_live_xxx swift run IslandCoreCLI
 //
-// Exercises the full pipeline:
+// Manus mode (default):
+//   MANUS_API_KEY_DEV=sk-xxx swift run IslandCoreCLI
 //   1. Start WebhookServer (port 7823)
 //   2. Launch cloudflared tunnel → get public URL
 //   3. Register webhook with Manus
 //   4. Wait 60s for events (create a task in Manus web UI)
 //   5. Print all received events
 //   6. Cleanup (delete webhook, stop tunnel)
+//
+// Claude Code mode:
+//   swift run IslandCoreCLI claude-hooks
+//   Starts LocalHookServer + ClaudeCodeConnector, prints the task snapshot
+//   after every event. Exercise it from another terminal, e.g.:
+//     echo '{"session_id":"s1","cwd":"'$PWD'","hook_event_name":"SessionStart"}' \
+//       | curl -sf -m 2 -X POST http://127.0.0.1:7824/hooks/claude-code \
+//              -H 'Content-Type: application/json' --data-binary @-
+
+if CommandLine.arguments.contains("claude-hooks") {
+    setvbuf(stdout, nil, _IONBF, 0)  // unbuffered so piped output appears live
+    print("[CLI] Claude Code hooks mode — LocalHookServer on 127.0.0.1:\(ClaudeHooksInstaller.defaultPort)")
+    print("[CLI] Hook command that would be installed:")
+    print("[CLI]   \(ClaudeHooksInstaller.hookCommand())")
+    print("[CLI] Waiting for events (Ctrl+C to stop)...")
+
+    let connector = ClaudeCodeConnector()
+    let server = LocalHookServer()
+    Task {
+        await server.start { event in
+            Task {
+                let snapshot = await connector.apply(event)
+                print("[CLI] ← \(event.hookEventName.rawValue) session=\(event.sessionId)")
+                for task in snapshot {
+                    print("[CLI]   • [\(task.status.rawValue)] \(task.title) (\(task.id))")
+                }
+                if snapshot.isEmpty { print("[CLI]   (no active sessions)") }
+            }
+        }
+    }
+    RunLoop.main.run()
+    exit(0)
+}
 
 guard let apiKey = ProcessInfo.processInfo.environment["MANUS_API_KEY_DEV"] else {
     print("[CLI] ✗ MANUS_API_KEY_DEV environment variable not set")

--- a/IslandCoreTests/Sources/IslandCoreTests/ClaudeCodeConnectorTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/ClaudeCodeConnectorTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class ClaudeCodeConnectorTests: XCTestCase {
+
+    // MARK: - Event decoding (same decoder config as LocalHookServer)
+
+    private func decode(_ json: String) throws -> ClaudeCodeEvent {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ClaudeCodeEvent.self, from: Data(json.utf8))
+    }
+
+    func testDecodeSessionStart() throws {
+        let event = try decode("""
+        {"session_id":"s1","transcript_path":"/tmp/t.jsonl","cwd":"/Users/dev/Proj","hook_event_name":"SessionStart"}
+        """)
+        XCTAssertEqual(event.hookEventName, .sessionStart)
+        XCTAssertEqual(event.sessionId, "s1")
+        XCTAssertEqual(event.cwd, "/Users/dev/Proj")
+    }
+
+    func testDecodeNotificationWithType() throws {
+        let event = try decode("""
+        {"session_id":"s1","hook_event_name":"Notification","message":"Claude needs permission to run Bash","notification_type":"permission_prompt"}
+        """)
+        XCTAssertEqual(event.hookEventName, .notification)
+        XCTAssertEqual(event.notificationType, "permission_prompt")
+        XCTAssertEqual(event.message, "Claude needs permission to run Bash")
+    }
+
+    func testDecodeUnknownEventFails() {
+        XCTAssertThrowsError(try decode("""
+        {"session_id":"s1","hook_event_name":"PreToolUse"}
+        """))
+    }
+
+    // MARK: - Lifecycle mapping
+
+    private func event(
+        _ kind: ClaudeCodeEvent.Kind,
+        session: String = "s1",
+        cwd: String? = "/Users/dev/Proj",
+        message: String? = nil,
+        type: String? = nil
+    ) -> ClaudeCodeEvent {
+        ClaudeCodeEvent(
+            hookEventName: kind, sessionId: session, cwd: cwd,
+            message: message, notificationType: type)
+    }
+
+    func testSessionLifecycle() async {
+        let connector = ClaudeCodeConnector()
+
+        var tasks = await connector.apply(event(.sessionStart))
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].id, "s1")
+        XCTAssertEqual(tasks[0].source, "claude-code")
+        XCTAssertEqual(tasks[0].status, .running)
+        XCTAssertEqual(tasks[0].title, "Proj")
+        XCTAssertEqual(tasks[0].taskURL, "file:///Users/dev/Proj/")
+
+        tasks = await connector.apply(
+            event(.notification, message: "Needs permission", type: "permission_prompt"))
+        XCTAssertEqual(tasks[0].status, .waiting)
+        XCTAssertEqual(tasks[0].waitingMessage, "Needs permission")
+
+        tasks = await connector.apply(event(.userPromptSubmit))
+        XCTAssertEqual(tasks[0].status, .running)
+        XCTAssertNil(tasks[0].waitingMessage)
+
+        tasks = await connector.apply(event(.stop))
+        XCTAssertEqual(tasks[0].status, .completed)
+
+        tasks = await connector.apply(event(.sessionEnd))
+        XCTAssertTrue(tasks.isEmpty)
+    }
+
+    func testStopFailureMarksFailed() async {
+        let connector = ClaudeCodeConnector()
+        _ = await connector.apply(event(.sessionStart))
+        let tasks = await connector.apply(event(.stopFailure))
+        XCTAssertEqual(tasks[0].status, .failed)
+    }
+
+    func testIgnorableNotificationDoesNotCreateSession() async {
+        let connector = ClaudeCodeConnector()
+        let tasks = await connector.apply(event(.notification, type: "auth_success"))
+        XCTAssertTrue(tasks.isEmpty)
+    }
+
+    func testNotificationWithoutTypeTreatedAsWaiting() async {
+        let connector = ClaudeCodeConnector()
+        _ = await connector.apply(event(.sessionStart))
+        let tasks = await connector.apply(event(.notification, message: "Attention"))
+        XCTAssertEqual(tasks[0].status, .waiting)
+    }
+
+    func testStopOnUnseenSessionCreatesCompletedTask() async {
+        // Dev Island may launch mid-session — a lone Stop should still
+        // surface the session instead of being dropped.
+        let connector = ClaudeCodeConnector()
+        let tasks = await connector.apply(event(.stop))
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].status, .completed)
+    }
+
+    func testMultipleSessionsSortedByCreation() async {
+        let connector = ClaudeCodeConnector()
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        _ = await connector.apply(event(.sessionStart, session: "a"), now: t0)
+        let tasks = await connector.apply(
+            event(.sessionStart, session: "b", cwd: "/Users/dev/Other"),
+            now: t0.addingTimeInterval(60))
+        XCTAssertEqual(tasks.map(\.id), ["a", "b"])
+    }
+
+    func testFinishedSessionsPrunedAfterTTL() async {
+        let connector = ClaudeCodeConnector()
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        _ = await connector.apply(event(.sessionStart, session: "old"), now: t0)
+        _ = await connector.apply(event(.stop, session: "old"), now: t0)
+
+        // Just under the TTL: still visible.
+        var tasks = await connector.apply(
+            event(.sessionStart, session: "new"),
+            now: t0.addingTimeInterval(ClaudeCodeConnector.finishedTTL - 1))
+        XCTAssertEqual(tasks.count, 2)
+
+        // Past the TTL: pruned.
+        tasks = await connector.apply(
+            event(.userPromptSubmit, session: "new"),
+            now: t0.addingTimeInterval(ClaudeCodeConnector.finishedTTL + 1))
+        XCTAssertEqual(tasks.map(\.id), ["new"])
+    }
+}

--- a/IslandCoreTests/Sources/IslandCoreTests/ClaudeHooksInstallerTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/ClaudeHooksInstallerTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class ClaudeHooksInstallerTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var settingsURL: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-hooks-\(UUID().uuidString)")
+        settingsURL = tempDir.appendingPathComponent("settings.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func readRoot() throws -> [String: Any] {
+        let data = try Data(contentsOf: settingsURL)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - Tests
+
+    func testInstallIntoMissingFile() throws {
+        XCTAssertFalse(ClaudeHooksInstaller.isInstalled(settingsURL: settingsURL))
+        try ClaudeHooksInstaller.install(settingsURL: settingsURL)
+        XCTAssertTrue(ClaudeHooksInstaller.isInstalled(settingsURL: settingsURL))
+
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        XCTAssertEqual(Set(hooks.keys), Set(ClaudeHooksInstaller.events))
+    }
+
+    func testInstallPreservesExistingSettingsAndHooks() throws {
+        let existing: [String: Any] = [
+            "model": "opus",
+            "hooks": [
+                "Stop": [
+                    ["matcher": "", "hooks": [["type": "command", "command": "terminal-notifier -message done"]]]
+                ]
+            ],
+        ]
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: existing).write(to: settingsURL)
+
+        try ClaudeHooksInstaller.install(settingsURL: settingsURL)
+
+        let root = try readRoot()
+        XCTAssertEqual(root["model"] as? String, "opus")
+        let stopGroups = try XCTUnwrap((root["hooks"] as? [String: Any])?["Stop"] as? [[String: Any]])
+        XCTAssertEqual(stopGroups.count, 2)  // user's + ours
+        let commands = stopGroups.flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
+            .compactMap { $0["command"] as? String }
+        XCTAssertTrue(commands.contains { $0.contains("terminal-notifier") })
+        XCTAssertTrue(commands.contains { $0.contains("/hooks/claude-code") })
+    }
+
+    func testInstallIsIdempotent() throws {
+        try ClaudeHooksInstaller.install(settingsURL: settingsURL)
+        try ClaudeHooksInstaller.install(settingsURL: settingsURL)
+
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        for event in ClaudeHooksInstaller.events {
+            let groups = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertEqual(groups.count, 1, "duplicate group for \(event)")
+        }
+    }
+
+    func testUninstallRemovesOnlyOurs() throws {
+        let existing: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["matcher": "", "hooks": [["type": "command", "command": "terminal-notifier -message done"]]]
+                ]
+            ]
+        ]
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: existing).write(to: settingsURL)
+
+        try ClaudeHooksInstaller.install(settingsURL: settingsURL)
+        try ClaudeHooksInstaller.uninstall(settingsURL: settingsURL)
+
+        XCTAssertFalse(ClaudeHooksInstaller.isInstalled(settingsURL: settingsURL))
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        // The user's Stop hook survives; our event keys are gone entirely.
+        XCTAssertEqual(Set(hooks.keys), ["Stop"])
+        let stopGroups = try XCTUnwrap(hooks["Stop"] as? [[String: Any]])
+        XCTAssertEqual(stopGroups.count, 1)
+    }
+
+    func testUninstallFromCleanInstallRemovesHooksKey() throws {
+        try ClaudeHooksInstaller.install(settingsURL: settingsURL)
+        try ClaudeHooksInstaller.uninstall(settingsURL: settingsURL)
+        XCTAssertNil(try readRoot()["hooks"])
+    }
+
+    func testHookCommandNeverFailsTheTurn() {
+        // The trailing `|| true` is a hard requirement: a dead Dev Island
+        // must never surface as a hook error inside Claude Code.
+        XCTAssertTrue(ClaudeHooksInstaller.hookCommand().hasSuffix("|| true"))
+        XCTAssertTrue(ClaudeHooksInstaller.hookCommand().contains("-m 2"))
+    }
+}

--- a/IslandCoreTests/Sources/IslandCoreTests/StateReconcilerTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/StateReconcilerTests.swift
@@ -5,10 +5,10 @@ final class StateReconcilerTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeTask(id: String, title: String = "Task", status: TaskStatus = .running, updatedAt: Date = .now) -> AgentTask {
+    private func makeTask(id: String, source: String = "manus", title: String = "Task", status: TaskStatus = .running, updatedAt: Date = .now) -> AgentTask {
         AgentTask(
             id: id,
-            source: "manus",
+            source: source,
             title: title,
             status: status,
             createdAt: Date(timeIntervalSinceReferenceDate: 0),
@@ -61,6 +61,33 @@ final class StateReconcilerTests: XCTestCase {
         let local = [makeTask(id: "t1"), makeTask(id: "t2")]
         let result = StateReconciler.reconcile(local: local, incoming: [])
         XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Source-scoped reconcile (Manus poll must not touch local sessions)
+
+    func testScopedReconcilePreservesOtherSources() {
+        let local = [
+            makeTask(id: "m1"),
+            makeTask(id: "c1", source: "claude-code"),
+        ]
+        // Manus snapshot no longer contains m1 — but c1 must survive.
+        let result = StateReconciler.reconcile(local: local, incoming: [], source: "manus")
+        XCTAssertEqual(result.map(\.id), ["c1"])
+    }
+
+    func testScopedReconcileMergesOwnSourceNormally() {
+        let old = Date(timeIntervalSinceReferenceDate: 100)
+        let new = Date(timeIntervalSinceReferenceDate: 200)
+        let local = [
+            makeTask(id: "m1", title: "Old", updatedAt: old),
+            makeTask(id: "c1", source: "claude-code"),
+        ]
+        let incoming = [makeTask(id: "m1", title: "New", updatedAt: new)]
+
+        let result = StateReconciler.reconcile(local: local, incoming: incoming, source: "manus")
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first { $0.id == "m1" }?.title, "New")
+        XCTAssertNotNil(result.first { $0.id == "c1" })
     }
 
     // MARK: - apply event tests

--- a/README.md
+++ b/README.md
@@ -113,9 +113,16 @@ mode you're in.
 | Source | Status |
 | --- | --- |
 | Manus | ✅ Available |
-| Claude Code | 🚧 Next up (local hooks, no tunnel needed) |
+| Claude Code | ✅ Available (local hooks, no tunnel needed) |
 | Codex CLI | 🚧 Next up (local notify hook) |
 | Cursor | 📋 Planned |
+
+**Claude Code** needs no API key: flip the toggle in *Settings → Connected
+Services → Claude Code*. Dev Island installs a fire-and-forget hook into
+`~/.claude/settings.json` that reports session lifecycle events
+(start / needs-input / done / failed) to a localhost-only endpoint. New
+sessions appear in the island within milliseconds; clicking one opens the
+project folder.
 
 The connector layer is intentionally pluggable — `IslandCore` exposes an
 `AgentConnector` protocol, and adding a new source is a matter of writing
@@ -158,7 +165,8 @@ changes go through [`docs/INTERFACE_CONTRACT.md`](docs/INTERFACE_CONTRACT.md).
 | Settings + Launch at Login + banner notifications | ✅ Shipping |
 | Signed + notarized public release | ✅ v0.1.1 on [Releases](https://github.com/sheepxux/Dev-Island/releases) |
 | Homebrew Cask tap | 🚧 Draft in `dist/homebrew-island/` |
-| Claude Code / Codex connectors | 📋 Next up |
+| Claude Code connector (local hooks) | ✅ Shipping |
+| Codex connector | 📋 Next up |
 
 ## Contributing
 

--- a/docs/INTERFACE_CONTRACT.md
+++ b/docs/INTERFACE_CONTRACT.md
@@ -81,8 +81,32 @@ public enum APIKeyStatus: Equatable, Sendable {
 
 ---
 
+## Claude Code 本地连接器(v1.1.0 新增)
+
+`TaskStore` 公开 API 不变。新增 C 侧可用的 IslandCore 公开类型:
+
+```swift
+/// hooks 安装器 — SettingsView 的 Claude Code 行直接调用
+public enum ClaudeHooksInstaller {
+    public static func isInstalled(settingsURL: URL? = nil) -> Bool
+    public static func install(settingsURL: URL? = nil, port: Int = defaultPort) throws
+    public static func uninstall(settingsURL: URL? = nil) throws
+}
+```
+
+行为约定:
+
+- `tasks` 里现在会出现 `source == "claude-code"` 的任务(TaskCard 已有 "C" logo 分支)
+- claude-code 任务的 `taskURL` 是项目目录的 `file://` URL,`openTaskInBrowser` 会打开 Finder
+- `stopTask` 对 claude-code 任务是 no-op(本地会话无法远程停止)
+- `clearAPIKey` 只清 Manus 任务,不影响本地会话
+- 本地管线(`LocalHookServer`,127.0.0.1:7824)随 app 启动,与 Manus key 无关
+
+---
+
 ## 变更记录
 
 | 日期 | 版本 | 描述 | Commit |
 |---|---|---|---|
 | 2026-04-24 | v1.0.0 | 初始版本 | `[S][contract] feat(store): initial TaskStore API` |
+| 2026-07-28 | v1.1.0 | Claude Code 本地连接器(TaskStore API 不变) | `[S] feat(claude-code): local hooks connector` |


### PR DESCRIPTION
## Summary
- New `LocalHookServer` (127.0.0.1:7824, deliberately separate from the tunnel-exposed `WebhookServer`) receives Claude Code lifecycle events from a fire-and-forget `curl` hook installed into `~/.claude/settings.json`
- `ClaudeCodeConnector` maps events to island states: SessionStart/UserPromptSubmit → running, Notification (permission/idle/input prompts) → waiting, Stop → completed, StopFailure → failed, SessionEnd → removed; TTL pruning for dead sessions
- `ClaudeHooksInstaller` does idempotent, merge-based settings.json editing — user hooks preserved, ours identified by the `/hooks/claude-code` marker; the hook command (`-m 2`, `|| true`) can never fail a Claude turn
- `TaskStore`: local pipeline runs with or without a Manus key; Manus polling reconcile is now source-scoped so it can't wipe local sessions; `clearAPIKey`/`stopTask` respect task source
- Settings gains a Claude Code Enable/Disable row (replaces Coming Soon); clicking a session task opens the project folder in Finder

## Test plan
- [x] `swift test` — 49/49 passing (18 new: event decoding, lifecycle mapping, installer merge/uninstall, source-scoped reconcile)
- [x] End-to-end via `swift run IslandCoreCLI claude-hooks` + curl: verified running → waiting → running → completed → removed
- [ ] Manual: enable in Settings, start a real Claude Code session, watch the island

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a localhost-only Claude Code connector so local sessions appear in the island without a tunnel or API key. Events from Claude Code map to task states (start/wait/done/failed), and clicking a session opens the project folder.

- New Features
  - LocalHookServer on 127.0.0.1:7824 receives hook JSON and always returns 200; separate from the public WebhookServer.
  - ClaudeHooksInstaller idempotently edits ~/.claude/settings.json, adds a `/hooks/claude-code` curl command (`-m 2`, `|| true`), preserves user hooks, and uninstalls cleanly.
  - ClaudeCodeConnector event-sources tasks: SessionStart/UserPromptSubmit → running; Notification → waiting; agent_completed/Stop → completed; StopFailure → failed; SessionEnd → removed; TTL pruning; taskURL points to the project folder.
  - TaskStore runs the local pipeline regardless of Manus; reconcile is source-scoped so Manus polling doesn’t wipe local sessions; `clearAPIKey` and `stopTask` only affect Manus tasks.
  - Settings adds a Claude Code Enable/Disable row with status and error feedback; replaces “Coming Soon”.
  - CLI adds `claude-hooks` mode for local testing; tests cover event decoding, lifecycle mapping, installer merge/uninstall, and scoped reconcile (49/49 passing).

- Migration
  - Enable in Settings → Connected Services → Claude Code. New Claude Code sessions will be tracked automatically; no API key required.

<sup>Written for commit f401f639f2f9897d18d0f01de784a20fa68e9ac6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sheepxux/Dev-Island/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

