### PR TITLE
[S] feat: Codex connector — second local source, shared plumbing

### DIFF
--- a/IslandAppLib/Views/NotchPanel/TaskCard.swift
+++ b/IslandAppLib/Views/NotchPanel/TaskCard.swift
@@ -92,6 +92,7 @@ struct TaskCard: View {
         switch task.source {
         case "manus":       return "M"
         case "claude-code": return "C"
+        case "codex":       return "Cx"
         case "cursor":      return "Cu"
         default:            return String(task.source.prefix(1)).uppercased()
         }

--- a/IslandAppLib/Views/Settings/SettingsView.swift
+++ b/IslandAppLib/Views/Settings/SettingsView.swift
@@ -71,7 +71,23 @@ private struct ConnectedServicesSection: View {
             VStack(spacing: 0) {
                 ManusServiceRow(store: store)
                 rowDivider
-                ClaudeCodeServiceRow()
+                LocalAgentServiceRow(
+                    name: "Claude Code",
+                    idleSubtitle: "Track local Claude Code sessions in the island",
+                    configPath: "~/.claude/settings.json",
+                    isInstalled: { ClaudeHooksInstaller.isInstalled() },
+                    install: { try ClaudeHooksInstaller.install() },
+                    uninstall: { try ClaudeHooksInstaller.uninstall() }
+                )
+                rowDivider
+                LocalAgentServiceRow(
+                    name: "Codex",
+                    idleSubtitle: "Track local Codex CLI sessions in the island",
+                    configPath: "~/.codex/hooks.json",
+                    isInstalled: { CodexHooksInstaller.isInstalled() },
+                    install: { try CodexHooksInstaller.install() },
+                    uninstall: { try CodexHooksInstaller.uninstall() }
+                )
                 rowDivider
                 ComingSoonRow(name: "Cursor", subtitle: "Editor-side task ingestion")
             }
@@ -219,40 +235,46 @@ private struct ManusServiceRow: View {
     }
 }
 
-// MARK: - Claude Code row
+// MARK: - Local agent row (Claude Code, Codex)
 
-/// Enables/disables the Claude Code integration by installing hook entries
-/// into `~/.claude/settings.json` (via `ClaudeHooksInstaller`). Sessions
-/// report their lifecycle to the always-running `LocalHookServer` — no API
-/// key, no tunnel.
-private struct ClaudeCodeServiceRow: View {
-    @State private var isInstalled = ClaudeHooksInstaller.isInstalled()
+/// Enables/disables a local CLI integration by installing hook entries into
+/// the CLI's config file (via the matching installer). Sessions report their
+/// lifecycle to the always-running `LocalHookServer` — no API key, no tunnel.
+private struct LocalAgentServiceRow: View {
+    let name: String
+    let idleSubtitle: String
+    let configPath: String
+    let isInstalled: () -> Bool
+    let install: () throws -> Void
+    let uninstall: () throws -> Void
+
+    @State private var installed = false
     @State private var lastError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
                 Circle()
-                    .fill(isInstalled ? Color.green : Color.secondary.opacity(0.5))
+                    .fill(installed ? Color.green : Color.secondary.opacity(0.5))
                     .frame(width: 8, height: 8)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Claude Code").font(.system(size: 13, weight: .semibold))
-                    Text(isInstalled
+                    Text(name).font(.system(size: 13, weight: .semibold))
+                    Text(installed
                          ? "Hooks installed — sessions report status live"
-                         : "Track local Claude Code sessions in the island")
+                         : idleSubtitle)
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                if isInstalled {
-                    Button("Disable", role: .destructive) { uninstall() }
+                if installed {
+                    Button("Disable", role: .destructive) { toggle(uninstall, to: false) }
                 } else {
-                    Button("Enable") { install() }
+                    Button("Enable") { toggle(install, to: true) }
                 }
             }
 
-            if isInstalled {
-                Text("Applies to Claude Code sessions started after enabling.")
+            if installed {
+                Text("Applies to \(name) sessions started after enabling.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
@@ -264,25 +286,16 @@ private struct ClaudeCodeServiceRow: View {
             }
         }
         .padding(16)
+        .onAppear { installed = isInstalled() }
     }
 
-    private func install() {
+    private func toggle(_ action: () throws -> Void, to newState: Bool) {
         do {
-            try ClaudeHooksInstaller.install()
-            isInstalled = true
+            try action()
+            installed = newState
             lastError = nil
         } catch {
-            lastError = "Couldn't update ~/.claude/settings.json: \(error.localizedDescription)"
-        }
-    }
-
-    private func uninstall() {
-        do {
-            try ClaudeHooksInstaller.uninstall()
-            isInstalled = false
-            lastError = nil
-        } catch {
-            lastError = "Couldn't update ~/.claude/settings.json: \(error.localizedDescription)"
+            lastError = "Couldn't update \(configPath): \(error.localizedDescription)"
         }
     }
 }

--- a/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeCodeConnector.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeCodeConnector.swift
@@ -26,20 +26,17 @@ public actor ClaudeCodeConnector: AgentConnector {
         "auth_success", "elicitation_complete", "elicitation_response",
     ]
 
-    /// Finished sessions linger briefly so the user sees the green state,
-    /// then get pruned. Sessions that stop emitting events entirely (e.g.
-    /// Claude Code crashed before SessionEnd) are dropped after a day.
-    static let finishedTTL: TimeInterval = 2 * 60 * 60
-    static let staleTTL: TimeInterval = 24 * 60 * 60
+    public static let finishedTTL = LocalSessionTable.finishedTTL
+    public static let staleTTL = LocalSessionTable.staleTTL
 
-    private var sessions: [String: AgentTask] = [:]
+    private var table = LocalSessionTable(source: "claude-code", displayName: "Claude Code")
 
     public init() {}
 
     // MARK: - AgentConnector
 
     public func fetchTasks() async throws -> [AgentTask] {
-        snapshot()
+        table.snapshot()
     }
 
     nonisolated public func openInBrowser(taskId: String) {
@@ -54,11 +51,11 @@ public actor ClaudeCodeConnector: AgentConnector {
 
     /// Apply one hook event and return the updated task snapshot.
     public func apply(_ event: ClaudeCodeEvent, now: Date = .now) -> [AgentTask] {
-        prune(now: now)
+        table.prune(now: now)
 
         switch event.hookEventName {
         case .sessionStart, .userPromptSubmit:
-            upsert(event, now: now) { task in
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
                 task.status = .running
                 task.currentPhase = nil
                 task.waitingMessage = nil
@@ -68,24 +65,24 @@ public actor ClaudeCodeConnector: AgentConnector {
             applyNotification(event, now: now)
 
         case .stop:
-            upsert(event, now: now) { task in
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
                 task.status = .completed
                 task.currentPhase = nil
                 task.waitingMessage = nil
             }
 
         case .stopFailure:
-            upsert(event, now: now) { task in
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
                 task.status = .failed
                 task.currentPhase = "Turn ended with an API error"
                 task.waitingMessage = nil
             }
 
         case .sessionEnd:
-            sessions.removeValue(forKey: event.sessionId)
+            table.remove(id: event.sessionId)
         }
 
-        return snapshot()
+        return table.snapshot()
     }
 
     // MARK: - Private
@@ -97,7 +94,7 @@ public actor ClaudeCodeConnector: AgentConnector {
             return
         }
         if type == "agent_completed" {
-            upsert(event, now: now) { task in
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
                 task.status = .completed
                 task.currentPhase = nil
                 task.waitingMessage = nil
@@ -106,44 +103,10 @@ public actor ClaudeCodeConnector: AgentConnector {
         }
         // Known waiting subtypes — and, defensively, any unknown/missing
         // subtype: a notification generally means Claude wants attention.
-        upsert(event, now: now) { task in
+        table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
             task.status = .waiting
             task.currentPhase = "Needs input"
             task.waitingMessage = event.message
         }
-    }
-
-    private func upsert(_ event: ClaudeCodeEvent, now: Date, mutate: (inout AgentTask) -> Void) {
-        var task = sessions[event.sessionId] ?? Self.newTask(for: event, now: now)
-        mutate(&task)
-        task.updatedAt = now
-        sessions[event.sessionId] = task
-    }
-
-    private static func newTask(for event: ClaudeCodeEvent, now: Date) -> AgentTask {
-        let projectURL = event.cwd.map { URL(fileURLWithPath: $0, isDirectory: true) }
-        return AgentTask(
-            id: event.sessionId,
-            source: "claude-code",
-            title: projectURL?.lastPathComponent ?? "Claude Code session",
-            status: .running,
-            createdAt: now,
-            updatedAt: now,
-            taskURL: projectURL?.absoluteString ?? ""
-        )
-    }
-
-    private func prune(now: Date) {
-        sessions = sessions.filter { _, task in
-            let age = now.timeIntervalSince(task.updatedAt)
-            switch task.status {
-            case .completed, .failed: return age < Self.finishedTTL
-            case .running, .waiting:  return age < Self.staleTTL
-            }
-        }
-    }
-
-    private func snapshot() -> [AgentTask] {
-        sessions.values.sorted { $0.createdAt < $1.createdAt }
     }
 }

--- a/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeHooksInstaller.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/ClaudeCode/ClaudeHooksInstaller.swift
@@ -8,10 +8,9 @@ import Foundation
 /// (`-m 2`, trailing `|| true`) so a stopped or crashed Dev Island can never
 /// block or fail a Claude Code turn.
 ///
-/// All edits are merge-based via `JSONSerialization`: existing user hooks,
-/// unknown settings keys, and unrelated hook groups are preserved verbatim.
-/// Our entries are recognized by the `/hooks/claude-code` marker in the
-/// command string, which makes install idempotent and uninstall surgical.
+/// JSON surgery is delegated to `HookConfigEditor` (shared with the Codex
+/// installer): existing user hooks and unknown settings keys are preserved,
+/// and our entries are recognized by the `/hooks/claude-code` marker.
 public enum ClaudeHooksInstaller {
 
     public static let defaultPort = 7824
@@ -37,87 +36,29 @@ public enum ClaudeHooksInstaller {
     // MARK: - Public API
 
     public static func isInstalled(settingsURL: URL? = nil) -> Bool {
-        let url = settingsURL ?? defaultSettingsURL
-        guard let root = readSettings(at: url),
-              let hooks = root["hooks"] as? [String: Any] else { return false }
-        // Consider installed when every event we need carries our command.
-        return events.allSatisfy { event in
-            guard let groups = hooks[event] as? [[String: Any]] else { return false }
-            return groups.contains(where: isOurGroup)
-        }
+        HookConfigEditor.isInstalled(
+            at: settingsURL ?? defaultSettingsURL,
+            events: events,
+            marker: endpointPath
+        )
     }
 
     public static func install(settingsURL: URL? = nil, port: Int = defaultPort) throws {
-        let url = settingsURL ?? defaultSettingsURL
-        var root = readSettings(at: url) ?? [:]
-        var hooks = root["hooks"] as? [String: Any] ?? [:]
-
-        let ourGroup: [String: Any] = [
-            "matcher": "",
-            "hooks": [["type": "command", "command": hookCommand(port: port)]],
-        ]
-
-        for event in events {
-            var groups = hooks[event] as? [[String: Any]] ?? []
-            groups.removeAll(where: isOurGroup)  // drop stale versions of ours
-            groups.append(ourGroup)
-            hooks[event] = groups
-        }
-
-        root["hooks"] = hooks
-        try writeSettings(root, to: url)
+        try HookConfigEditor.install(
+            at: settingsURL ?? defaultSettingsURL,
+            events: events,
+            group: [
+                "matcher": "",
+                "hooks": [["type": "command", "command": hookCommand(port: port)]],
+            ],
+            marker: endpointPath
+        )
     }
 
     public static func uninstall(settingsURL: URL? = nil) throws {
-        let url = settingsURL ?? defaultSettingsURL
-        guard var root = readSettings(at: url),
-              var hooks = root["hooks"] as? [String: Any] else { return }
-
-        for (event, value) in hooks {
-            guard var groups = value as? [[String: Any]] else { continue }
-            groups.removeAll(where: isOurGroup)
-            if groups.isEmpty {
-                hooks.removeValue(forKey: event)
-            } else {
-                hooks[event] = groups
-            }
-        }
-
-        if hooks.isEmpty {
-            root.removeValue(forKey: "hooks")
-        } else {
-            root["hooks"] = hooks
-        }
-        try writeSettings(root, to: url)
-    }
-
-    // MARK: - Private
-
-    /// A matcher group is "ours" when every command in it targets our
-    /// local endpoint (user-authored groups are never all-ours).
-    private static func isOurGroup(_ group: [String: Any]) -> Bool {
-        guard let handlers = group["hooks"] as? [[String: Any]], !handlers.isEmpty else {
-            return false
-        }
-        return handlers.allSatisfy { handler in
-            (handler["command"] as? String)?.contains(endpointPath) == true
-        }
-    }
-
-    private static func readSettings(at url: URL) -> [String: Any]? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-    }
-
-    private static func writeSettings(_ root: [String: Any], to url: URL) throws {
-        try FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+        try HookConfigEditor.uninstall(
+            at: settingsURL ?? defaultSettingsURL,
+            marker: endpointPath
         )
-        let data = try JSONSerialization.data(
-            withJSONObject: root,
-            options: [.prettyPrinted, .sortedKeys]
-        )
-        try data.write(to: url, options: .atomic)
     }
 }

--- a/IslandCore/Sources/IslandCore/Connectors/Codex/CodexConnector.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Codex/CodexConnector.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Tracks local Codex CLI sessions as `AgentTask`s.
+///
+/// Event-sourced from hook callbacks delivered by `LocalHookServer`, same
+/// as `ClaudeCodeConnector`. Session bookkeeping lives in
+/// `LocalSessionTable`; this type only supplies the Codex event vocabulary.
+///
+/// Status mapping:
+///   SessionStart / UserPromptSubmit → .running
+///   PermissionRequest               → .waiting (Codex is about to ask)
+///   Stop                            → .completed
+///   SessionEnd                      → session removed
+public actor CodexConnector: AgentConnector {
+    public let source = "codex"
+
+    private var table = LocalSessionTable(source: "codex", displayName: "Codex")
+
+    public init() {}
+
+    // MARK: - AgentConnector
+
+    public func fetchTasks() async throws -> [AgentTask] {
+        table.snapshot()
+    }
+
+    nonisolated public func openInBrowser(taskId: String) {
+        // URL opening is handled by TaskStore.openTaskInBrowser(id:).
+    }
+
+    public func stop(taskId: String) async throws {
+        // Local sessions can't be stopped remotely — no-op by design.
+    }
+
+    // MARK: - Event ingestion
+
+    /// Apply one hook event and return the updated task snapshot.
+    public func apply(_ event: CodexEvent, now: Date = .now) -> [AgentTask] {
+        table.prune(now: now)
+
+        switch event.hookEventName {
+        case .sessionStart, .userPromptSubmit:
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
+                task.status = .running
+                task.currentPhase = nil
+                task.waitingMessage = nil
+            }
+
+        case .permissionRequest:
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
+                task.status = .waiting
+                task.currentPhase = "Needs approval"
+                task.waitingMessage = event.toolName.map { "Approval needed: \($0)" }
+                    ?? "Approval needed"
+            }
+
+        case .stop:
+            table.upsert(id: event.sessionId, cwd: event.cwd, now: now) { task in
+                task.status = .completed
+                task.currentPhase = nil
+                task.waitingMessage = nil
+            }
+
+        case .sessionEnd:
+            table.remove(id: event.sessionId)
+        }
+
+        return table.snapshot()
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/Codex/CodexEvent.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Codex/CodexEvent.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// One lifecycle event emitted by a Codex CLI hook.
+///
+/// Codex's hooks engine pipes a JSON object on stdin to command hooks —
+/// the same transport as Claude Code, with the same core fields
+/// (`session_id`, `cwd`, `hook_event_name`). Our installed `curl` hook
+/// forwards it verbatim to `LocalHookServer` on `/hooks/codex`.
+///
+/// Only the events we install hooks for are modeled. Anything else fails to
+/// decode and is dropped by the server without disturbing Codex.
+public struct CodexEvent: Decodable, Sendable {
+
+    public enum Kind: String, Decodable, Sendable {
+        case sessionStart      = "SessionStart"
+        case userPromptSubmit  = "UserPromptSubmit"
+        case permissionRequest = "PermissionRequest"
+        case stop              = "Stop"
+        case sessionEnd        = "SessionEnd"
+    }
+
+    public let hookEventName: Kind
+    public let sessionId: String
+    /// Working directory of the session. Used for the task title and the
+    /// open-in-Finder URL.
+    public let cwd: String?
+    /// Tool awaiting approval — set on `PermissionRequest` events.
+    public let toolName: String?
+
+    public init(
+        hookEventName: Kind,
+        sessionId: String,
+        cwd: String? = nil,
+        toolName: String? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.sessionId = sessionId
+        self.cwd = cwd
+        self.toolName = toolName
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/Codex/CodexHooksInstaller.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Codex/CodexHooksInstaller.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Installs / removes the Dev Island hook entries in Codex's user-level
+/// hooks file (`~/.codex/hooks.json`).
+///
+/// Codex loads hooks from `hooks.json` next to `config.toml` — same event
+/// nesting as Claude Code's settings, so `HookConfigEditor` does the JSON
+/// surgery. We deliberately use `hooks.json` instead of inline TOML: it's
+/// mergeable without a TOML dependency, and Codex warns if both exist in
+/// one layer (we never touch `config.toml`).
+///
+/// The command is fire-and-forget (`-m 2`, `|| true`, output discarded):
+/// exit 0 with no stdout is defined by Codex as "success, continue", so a
+/// dead Dev Island can never stall or steer a Codex turn.
+public enum CodexHooksInstaller {
+
+    /// Hook events we subscribe to. Keep in sync with `CodexEvent.Kind`.
+    static let events = [
+        "SessionStart", "UserPromptSubmit", "PermissionRequest",
+        "Stop", "SessionEnd",
+    ]
+
+    static let endpointPath = "/hooks/codex"
+
+    public static func hookCommand(port: Int = ClaudeHooksInstaller.defaultPort) -> String {
+        "curl -sf -m 2 -X POST http://127.0.0.1:\(port)\(endpointPath) "
+            + "-H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true"
+    }
+
+    public static var defaultHooksURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/hooks.json")
+    }
+
+    // MARK: - Public API
+
+    public static func isInstalled(hooksURL: URL? = nil) -> Bool {
+        HookConfigEditor.isInstalled(
+            at: hooksURL ?? defaultHooksURL,
+            events: events,
+            marker: endpointPath
+        )
+    }
+
+    public static func install(hooksURL: URL? = nil, port: Int = ClaudeHooksInstaller.defaultPort) throws {
+        // No "matcher" key: Codex matchers are event-specific (SessionStart
+        // filters start source, PermissionRequest filters tool name) and an
+        // omitted matcher matches everything, which is what we want.
+        try HookConfigEditor.install(
+            at: hooksURL ?? defaultHooksURL,
+            events: events,
+            group: [
+                "hooks": [["type": "command", "command": hookCommand(port: port)]]
+            ],
+            marker: endpointPath
+        )
+    }
+
+    public static func uninstall(hooksURL: URL? = nil) throws {
+        try HookConfigEditor.uninstall(
+            at: hooksURL ?? defaultHooksURL,
+            marker: endpointPath
+        )
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/HookConfigEditor.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/HookConfigEditor.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Merge-based editing of hook config files that share the
+/// `{"hooks": {"Event": [{matcher?, hooks: [{type, command}]}]}}` nesting —
+/// Claude Code's `~/.claude/settings.json` and Codex's `~/.codex/hooks.json`
+/// use the identical structure.
+///
+/// Guarantees:
+/// - unknown top-level keys and user-authored hook groups survive untouched
+/// - our groups are recognized by an endpoint marker inside the command
+///   string, making install idempotent and uninstall surgical
+enum HookConfigEditor {
+
+    static func isInstalled(at url: URL, events: [String], marker: String) -> Bool {
+        guard let root = readRoot(at: url),
+              let hooks = root["hooks"] as? [String: Any] else { return false }
+        // Installed = every event we need carries our command.
+        return events.allSatisfy { event in
+            guard let groups = hooks[event] as? [[String: Any]] else { return false }
+            return groups.contains { isOurGroup($0, marker: marker) }
+        }
+    }
+
+    static func install(at url: URL, events: [String], group: [String: Any], marker: String) throws {
+        var root = readRoot(at: url) ?? [:]
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+
+        for event in events {
+            var groups = hooks[event] as? [[String: Any]] ?? []
+            groups.removeAll { isOurGroup($0, marker: marker) }  // drop stale versions
+            groups.append(group)
+            hooks[event] = groups
+        }
+
+        root["hooks"] = hooks
+        try writeRoot(root, to: url)
+    }
+
+    static func uninstall(at url: URL, marker: String) throws {
+        guard var root = readRoot(at: url),
+              var hooks = root["hooks"] as? [String: Any] else { return }
+
+        for (event, value) in hooks {
+            guard var groups = value as? [[String: Any]] else { continue }
+            groups.removeAll { isOurGroup($0, marker: marker) }
+            if groups.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = groups
+            }
+        }
+
+        if hooks.isEmpty {
+            root.removeValue(forKey: "hooks")
+        } else {
+            root["hooks"] = hooks
+        }
+        try writeRoot(root, to: url)
+    }
+
+    // MARK: - Private
+
+    /// A matcher group is "ours" when every command in it targets our
+    /// endpoint (user-authored groups are never all-ours).
+    private static func isOurGroup(_ group: [String: Any], marker: String) -> Bool {
+        guard let handlers = group["hooks"] as? [[String: Any]], !handlers.isEmpty else {
+            return false
+        }
+        return handlers.allSatisfy { handler in
+            (handler["command"] as? String)?.contains(marker) == true
+        }
+    }
+
+    private static func readRoot(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func writeRoot(_ root: [String: Any], to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/LocalSessionTable.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/LocalSessionTable.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Shared session bookkeeping for local CLI connectors (Claude Code, Codex).
+///
+/// Each connector decodes its own hook payloads and translates them into
+/// mutations on this table; the table owns the generic concerns — task
+/// creation, TTL pruning, and stable snapshot ordering.
+struct LocalSessionTable {
+    /// Finished sessions linger briefly so the user sees the green state,
+    /// then get pruned. Sessions that stop emitting events entirely (e.g.
+    /// the CLI crashed before its SessionEnd fired) are dropped after a day.
+    static let finishedTTL: TimeInterval = 2 * 60 * 60
+    static let staleTTL: TimeInterval = 24 * 60 * 60
+
+    let source: String
+    /// Human-readable fallback for the task title when `cwd` is missing.
+    let displayName: String
+    private var sessions: [String: AgentTask] = [:]
+
+    init(source: String, displayName: String) {
+        self.source = source
+        self.displayName = displayName
+    }
+
+    /// Create-or-update the session task, then apply `mutate`.
+    mutating func upsert(id: String, cwd: String?, now: Date, mutate: (inout AgentTask) -> Void) {
+        var task = sessions[id] ?? newTask(id: id, cwd: cwd, now: now)
+        mutate(&task)
+        task.updatedAt = now
+        sessions[id] = task
+    }
+
+    mutating func remove(id: String) {
+        sessions.removeValue(forKey: id)
+    }
+
+    mutating func prune(now: Date) {
+        sessions = sessions.filter { _, task in
+            let age = now.timeIntervalSince(task.updatedAt)
+            switch task.status {
+            case .completed, .failed: return age < Self.finishedTTL
+            case .running, .waiting:  return age < Self.staleTTL
+            }
+        }
+    }
+
+    func snapshot() -> [AgentTask] {
+        sessions.values.sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func contains(id: String) -> Bool {
+        sessions[id] != nil
+    }
+
+    private func newTask(id: String, cwd: String?, now: Date) -> AgentTask {
+        let projectURL = cwd.map { URL(fileURLWithPath: $0, isDirectory: true) }
+        return AgentTask(
+            id: id,
+            source: source,
+            title: projectURL?.lastPathComponent ?? "\(displayName) session",
+            status: .running,
+            createdAt: now,
+            updatedAt: now,
+            taskURL: projectURL?.absoluteString ?? ""
+        )
+    }
+}

--- a/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
+++ b/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
@@ -19,24 +19,24 @@ public actor LocalHookServer {
         self.port = port
     }
 
-    public func start(onClaudeCodeEvent: @escaping @Sendable (ClaudeCodeEvent) -> Void) {
+    public func start(
+        onClaudeCodeEvent: @escaping @Sendable (ClaudeCodeEvent) -> Void,
+        onCodexEvent: @escaping @Sendable (CodexEvent) -> Void
+    ) {
         serverTask = Task {
             let router = Router()
 
             router.post("/hooks/claude-code") { request, _ -> HTTPResponse.Status in
-                var buffer = try await request.body.collect(upTo: 1_048_576)
-                let data = Data(buffer.readableBytesView)
-
-                let decoder = JSONDecoder()
-                decoder.keyDecodingStrategy = .convertFromSnakeCase
-                guard let event = try? decoder.decode(ClaudeCodeEvent.self, from: data) else {
-                    IslandLogger.webhook.debug("Ignoring undecodable Claude Code hook payload")
-                    return .ok
+                if let event: ClaudeCodeEvent = await Self.decodeBody(of: request, cli: "Claude Code") {
+                    onClaudeCodeEvent(event)
                 }
+                return .ok
+            }
 
-                IslandLogger.webhook.info(
-                    "Claude Code event: \(event.hookEventName.rawValue) session=\(event.sessionId)")
-                onClaudeCodeEvent(event)
+            router.post("/hooks/codex") { request, _ -> HTTPResponse.Status in
+                if let event: CodexEvent = await Self.decodeBody(of: request, cli: "Codex") {
+                    onCodexEvent(event)
+                }
                 return .ok
             }
 
@@ -47,6 +47,22 @@ public actor LocalHookServer {
             IslandLogger.webhook.info("LocalHookServer listening on 127.0.0.1:\(self.port)")
             try await app.run()
         }
+    }
+
+    /// Decode a snake_case hook payload; undecodable bodies are dropped
+    /// silently (the endpoint always answers 200 either way).
+    private static func decodeBody<E: Decodable>(of request: Request, cli: String) async -> E? {
+        guard let buffer = try? await request.body.collect(upTo: 1_048_576) else { return nil }
+        let data = Data(buffer.readableBytesView)
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        guard let event = try? decoder.decode(E.self, from: data) else {
+            IslandLogger.webhook.debug("Ignoring undecodable \(cli) hook payload")
+            return nil
+        }
+        IslandLogger.webhook.info("\(cli) hook event received")
+        return event
     }
 
     public func stop() {

--- a/IslandCore/Sources/IslandCore/TaskStore.swift
+++ b/IslandCore/Sources/IslandCore/TaskStore.swift
@@ -21,10 +21,12 @@ public final class TaskStore {
     private var sqliteStore: SQLiteStore?
     private var pollingOnlyMode = false
 
-    // Local agent pipeline (Claude Code) — independent of the Manus API key
-    // and of the tunnel/polling lifecycle: it runs for the app's lifetime.
+    // Local agent pipeline (Claude Code, Codex) — independent of the Manus
+    // API key and of the tunnel/polling lifecycle: it runs for the app's
+    // lifetime.
     private var localHookServer: LocalHookServer?
     private var claudeConnector: ClaudeCodeConnector?
+    private var codexConnector: CodexConnector?
 
     private var sleepObserver: NSObjectProtocol?
     private var wakeObserver: NSObjectProtocol?
@@ -171,21 +173,32 @@ public final class TaskStore {
     // MARK: - Local agent pipeline (Claude Code)
 
     private func startLocalHookPipeline() {
-        let connector = ClaudeCodeConnector()
-        claudeConnector = connector
+        let claude = ClaudeCodeConnector()
+        claudeConnector = claude
+        let codex = CodexConnector()
+        codexConnector = codex
         let server = LocalHookServer()
         localHookServer = server
 
         Task {
-            await server.start { [weak self] event in
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    let snapshot = await connector.apply(event)
-                    self.applyLocalSnapshot(source: connector.source, snapshot)
+            await server.start(
+                onClaudeCodeEvent: { [weak self] event in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        let snapshot = await claude.apply(event)
+                        self.applyLocalSnapshot(source: claude.source, snapshot)
+                    }
+                },
+                onCodexEvent: { [weak self] event in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        let snapshot = await codex.apply(event)
+                        self.applyLocalSnapshot(source: codex.source, snapshot)
+                    }
                 }
-            }
+            )
         }
-        IslandLogger.store.info("Local hook pipeline started (claude-code)")
+        IslandLogger.store.info("Local hook pipeline started (claude-code, codex)")
     }
 
     // MARK: - Service lifecycle

--- a/IslandCoreCLI/Sources/IslandCoreCLI/main.swift
+++ b/IslandCoreCLI/Sources/IslandCoreCLI/main.swift
@@ -12,34 +12,49 @@ import IslandCore
 //   5. Print all received events
 //   6. Cleanup (delete webhook, stop tunnel)
 //
-// Claude Code mode:
-//   swift run IslandCoreCLI claude-hooks
-//   Starts LocalHookServer + ClaudeCodeConnector, prints the task snapshot
+// Local hooks mode (Claude Code + Codex):
+//   swift run IslandCoreCLI local-hooks
+//   Starts LocalHookServer + both local connectors, prints the task snapshot
 //   after every event. Exercise it from another terminal, e.g.:
 //     echo '{"session_id":"s1","cwd":"'$PWD'","hook_event_name":"SessionStart"}' \
 //       | curl -sf -m 2 -X POST http://127.0.0.1:7824/hooks/claude-code \
 //              -H 'Content-Type: application/json' --data-binary @-
+//   (same for /hooks/codex)
 
-if CommandLine.arguments.contains("claude-hooks") {
+if CommandLine.arguments.contains("local-hooks") || CommandLine.arguments.contains("claude-hooks") {
     setvbuf(stdout, nil, _IONBF, 0)  // unbuffered so piped output appears live
-    print("[CLI] Claude Code hooks mode — LocalHookServer on 127.0.0.1:\(ClaudeHooksInstaller.defaultPort)")
-    print("[CLI] Hook command that would be installed:")
-    print("[CLI]   \(ClaudeHooksInstaller.hookCommand())")
+    print("[CLI] Local hooks mode — LocalHookServer on 127.0.0.1:\(ClaudeHooksInstaller.defaultPort)")
+    print("[CLI] Claude Code hook command: \(ClaudeHooksInstaller.hookCommand())")
+    print("[CLI] Codex hook command:       \(CodexHooksInstaller.hookCommand())")
     print("[CLI] Waiting for events (Ctrl+C to stop)...")
 
-    let connector = ClaudeCodeConnector()
+    let claude = ClaudeCodeConnector()
+    let codex = CodexConnector()
     let server = LocalHookServer()
-    Task {
-        await server.start { event in
-            Task {
-                let snapshot = await connector.apply(event)
-                print("[CLI] ← \(event.hookEventName.rawValue) session=\(event.sessionId)")
-                for task in snapshot {
-                    print("[CLI]   • [\(task.status.rawValue)] \(task.title) (\(task.id))")
-                }
-                if snapshot.isEmpty { print("[CLI]   (no active sessions)") }
-            }
+
+    @Sendable func report(_ label: String, _ snapshot: [AgentTask]) {
+        print("[CLI] ← \(label)")
+        for task in snapshot {
+            print("[CLI]   • [\(task.source)/\(task.status.rawValue)] \(task.title) (\(task.id))")
         }
+        if snapshot.isEmpty { print("[CLI]   (no active sessions)") }
+    }
+
+    Task {
+        await server.start(
+            onClaudeCodeEvent: { event in
+                Task {
+                    let snapshot = await claude.apply(event)
+                    report("claude-code \(event.hookEventName.rawValue) session=\(event.sessionId)", snapshot)
+                }
+            },
+            onCodexEvent: { event in
+                Task {
+                    let snapshot = await codex.apply(event)
+                    report("codex \(event.hookEventName.rawValue) session=\(event.sessionId)", snapshot)
+                }
+            }
+        )
     }
     RunLoop.main.run()
     exit(0)

--- a/IslandCoreTests/Sources/IslandCoreTests/CodexConnectorTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/CodexConnectorTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class CodexConnectorTests: XCTestCase {
+
+    // MARK: - Event decoding (same decoder config as LocalHookServer)
+
+    private func decode(_ json: String) throws -> CodexEvent {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(CodexEvent.self, from: Data(json.utf8))
+    }
+
+    func testDecodeSessionStart() throws {
+        let event = try decode("""
+        {"session_id":"thr_123","transcript_path":"/w/.codex/rollout.jsonl","cwd":"/w/Proj","hook_event_name":"SessionStart","source":"startup","model":"gpt-5.6","permission_mode":"default"}
+        """)
+        XCTAssertEqual(event.hookEventName, .sessionStart)
+        XCTAssertEqual(event.sessionId, "thr_123")
+        XCTAssertEqual(event.cwd, "/w/Proj")
+    }
+
+    func testDecodePermissionRequestWithToolName() throws {
+        let event = try decode("""
+        {"session_id":"thr_123","cwd":"/w/Proj","hook_event_name":"PermissionRequest","tool_name":"Bash"}
+        """)
+        XCTAssertEqual(event.hookEventName, .permissionRequest)
+        XCTAssertEqual(event.toolName, "Bash")
+    }
+
+    func testDecodeUnsubscribedEventFails() {
+        XCTAssertThrowsError(try decode("""
+        {"session_id":"thr_123","hook_event_name":"PreToolUse"}
+        """))
+    }
+
+    // MARK: - Lifecycle mapping
+
+    private func event(
+        _ kind: CodexEvent.Kind,
+        session: String = "thr_1",
+        cwd: String? = "/Users/dev/Proj",
+        toolName: String? = nil
+    ) -> CodexEvent {
+        CodexEvent(hookEventName: kind, sessionId: session, cwd: cwd, toolName: toolName)
+    }
+
+    func testSessionLifecycle() async {
+        let connector = CodexConnector()
+
+        var tasks = await connector.apply(event(.sessionStart))
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].source, "codex")
+        XCTAssertEqual(tasks[0].status, .running)
+        XCTAssertEqual(tasks[0].title, "Proj")
+        XCTAssertEqual(tasks[0].taskURL, "file:///Users/dev/Proj/")
+
+        tasks = await connector.apply(event(.permissionRequest, toolName: "Bash"))
+        XCTAssertEqual(tasks[0].status, .waiting)
+        XCTAssertEqual(tasks[0].waitingMessage, "Approval needed: Bash")
+
+        tasks = await connector.apply(event(.userPromptSubmit))
+        XCTAssertEqual(tasks[0].status, .running)
+        XCTAssertNil(tasks[0].waitingMessage)
+
+        tasks = await connector.apply(event(.stop))
+        XCTAssertEqual(tasks[0].status, .completed)
+
+        tasks = await connector.apply(event(.sessionEnd))
+        XCTAssertTrue(tasks.isEmpty)
+    }
+
+    func testPermissionRequestWithoutToolName() async {
+        let connector = CodexConnector()
+        let tasks = await connector.apply(event(.permissionRequest))
+        XCTAssertEqual(tasks[0].status, .waiting)
+        XCTAssertEqual(tasks[0].waitingMessage, "Approval needed")
+    }
+
+    func testStopOnUnseenSessionCreatesCompletedTask() async {
+        let connector = CodexConnector()
+        let tasks = await connector.apply(event(.stop))
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].status, .completed)
+    }
+
+    func testClaudeAndCodexSessionsAreIndependent() async {
+        // Same session-id string on both connectors must not collide at the
+        // TaskStore level: sources differ, snapshots are per-source.
+        let claude = ClaudeCodeConnector()
+        let codex = CodexConnector()
+        let c1 = await claude.apply(ClaudeCodeEvent(
+            hookEventName: .sessionStart, sessionId: "s1", cwd: "/a"))
+        let x1 = await codex.apply(event(.sessionStart, session: "s1", cwd: "/b"))
+        XCTAssertEqual(c1[0].source, "claude-code")
+        XCTAssertEqual(x1[0].source, "codex")
+    }
+}

--- a/IslandCoreTests/Sources/IslandCoreTests/CodexHooksInstallerTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/CodexHooksInstallerTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class CodexHooksInstallerTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var hooksURL: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-codex-hooks-\(UUID().uuidString)")
+        hooksURL = tempDir.appendingPathComponent("hooks.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func readRoot() throws -> [String: Any] {
+        let data = try Data(contentsOf: hooksURL)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - Tests
+
+    func testInstallIntoMissingFile() throws {
+        XCTAssertFalse(CodexHooksInstaller.isInstalled(hooksURL: hooksURL))
+        try CodexHooksInstaller.install(hooksURL: hooksURL)
+        XCTAssertTrue(CodexHooksInstaller.isInstalled(hooksURL: hooksURL))
+
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        XCTAssertEqual(Set(hooks.keys), Set(CodexHooksInstaller.events))
+    }
+
+    func testGroupsOmitMatcherKey() throws {
+        // Codex matchers are event-specific filters; omitting the key
+        // matches everything, and an empty-string regex is undefined
+        // territory we deliberately avoid.
+        try CodexHooksInstaller.install(hooksURL: hooksURL)
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        for event in CodexHooksInstaller.events {
+            let groups = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertNil(groups[0]["matcher"], "unexpected matcher on \(event)")
+        }
+    }
+
+    func testInstallPreservesExistingHooksAndTopLevelKeys() throws {
+        let existing: [String: Any] = [
+            "description": "My workspace hooks",
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "python3 ~/notify.py"]]]
+                ]
+            ],
+        ]
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: existing).write(to: hooksURL)
+
+        try CodexHooksInstaller.install(hooksURL: hooksURL)
+
+        let root = try readRoot()
+        XCTAssertEqual(root["description"] as? String, "My workspace hooks")
+        let stopGroups = try XCTUnwrap((root["hooks"] as? [String: Any])?["Stop"] as? [[String: Any]])
+        XCTAssertEqual(stopGroups.count, 2)  // user's + ours
+    }
+
+    func testInstallIsIdempotent() throws {
+        try CodexHooksInstaller.install(hooksURL: hooksURL)
+        try CodexHooksInstaller.install(hooksURL: hooksURL)
+
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        for event in CodexHooksInstaller.events {
+            let groups = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertEqual(groups.count, 1, "duplicate group for \(event)")
+        }
+    }
+
+    func testUninstallRemovesOnlyOurs() throws {
+        let existing: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "python3 ~/notify.py"]]]
+                ]
+            ]
+        ]
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: existing).write(to: hooksURL)
+
+        try CodexHooksInstaller.install(hooksURL: hooksURL)
+        try CodexHooksInstaller.uninstall(hooksURL: hooksURL)
+
+        XCTAssertFalse(CodexHooksInstaller.isInstalled(hooksURL: hooksURL))
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        XCTAssertEqual(Set(hooks.keys), ["Stop"])
+    }
+
+    func testHookCommandNeverFailsTheTurn() {
+        // Exit 0 with no stdout is Codex's definition of "success, continue";
+        // `-m 2` + `|| true` + discarded output guarantee exactly that shape.
+        let cmd = CodexHooksInstaller.hookCommand()
+        XCTAssertTrue(cmd.hasSuffix("|| true"))
+        XCTAssertTrue(cmd.contains("-m 2"))
+        XCTAssertTrue(cmd.contains(">/dev/null"))
+        XCTAssertTrue(cmd.contains("/hooks/codex"))
+    }
+
+    func testDistinctEndpointsFromClaude() {
+        XCTAssertNotEqual(
+            CodexHooksInstaller.hookCommand(),
+            ClaudeHooksInstaller.hookCommand()
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ mode you're in.
 | --- | --- |
 | Manus | ✅ Available |
 | Claude Code | ✅ Available (local hooks, no tunnel needed) |
-| Codex CLI | 🚧 Next up (local notify hook) |
+| Codex CLI | ✅ Available (local hooks, no tunnel needed) |
 | Cursor | 📋 Planned |
 
-**Claude Code** needs no API key: flip the toggle in *Settings → Connected
-Services → Claude Code*. Dev Island installs a fire-and-forget hook into
-`~/.claude/settings.json` that reports session lifecycle events
-(start / needs-input / done / failed) to a localhost-only endpoint. New
-sessions appear in the island within milliseconds; clicking one opens the
-project folder.
+**Claude Code** and **Codex** need no API key: flip the toggle in
+*Settings → Connected Services*. Dev Island installs a fire-and-forget hook
+(into `~/.claude/settings.json` / `~/.codex/hooks.json`) that reports session
+lifecycle events (start / needs-input / approval-request / done / failed) to
+a localhost-only endpoint. New sessions appear in the island within
+milliseconds; clicking one opens the project folder.
 
 The connector layer is intentionally pluggable — `IslandCore` exposes an
 `AgentConnector` protocol, and adding a new source is a matter of writing
@@ -166,7 +166,8 @@ changes go through [`docs/INTERFACE_CONTRACT.md`](docs/INTERFACE_CONTRACT.md).
 | Signed + notarized public release | ✅ v0.1.1 on [Releases](https://github.com/sheepxux/Dev-Island/releases) |
 | Homebrew Cask tap | 🚧 Draft in `dist/homebrew-island/` |
 | Claude Code connector (local hooks) | ✅ Shipping |
-| Codex connector | 📋 Next up |
+| Codex connector (local hooks) | ✅ Shipping |
+| Cursor connector | 📋 Next up |
 
 ## Contributing
 

--- a/docs/INTERFACE_CONTRACT.md
+++ b/docs/INTERFACE_CONTRACT.md
@@ -110,3 +110,4 @@ public enum ClaudeHooksInstaller {
 |---|---|---|---|
 | 2026-04-24 | v1.0.0 | 初始版本 | `[S][contract] feat(store): initial TaskStore API` |
 | 2026-07-28 | v1.1.0 | Claude Code 本地连接器(TaskStore API 不变) | `[S] feat(claude-code): local hooks connector` |
+| 2026-07-28 | v1.2.0 | Codex 本地连接器:`CodexHooksInstaller`(API 形态同 `ClaudeHooksInstaller`,写 `~/.codex/hooks.json`),tasks 新增 `source == "codex"`,其余约定同 claude-code | `[S] feat(codex): local hooks connector` |


### PR DESCRIPTION
> Stacked on #3 (Claude Code connector) — merge that first, then retarget/merge this one.

## Summary
- Codex CLI sessions appear in the island via the same localhost pipeline: a fire-and-forget `curl` hook in `~/.codex/hooks.json` posts stdin JSON to the new `/hooks/codex` route on `LocalHookServer`
- `CodexConnector` maps SessionStart/UserPromptSubmit → running, PermissionRequest → waiting (with tool name), Stop → completed, SessionEnd → removed
- `CodexHooksInstaller` writes `~/.codex/hooks.json` only (no TOML dependency, never touches `config.toml`); hook groups omit `matcher` since Codex matchers are event-specific filters
- Shared internals extracted: `LocalSessionTable` (session bookkeeping + TTL pruning) and `HookConfigEditor` (merge-based hook-config surgery) — both connectors are now thin event-vocabulary layers, ready for the Cursor connector next
- Settings gets a generic local-agent row driving both toggles; TaskCard gets a "Cx" logo

## Test plan
- [x] `swift test` — 63/63 passing (14 new)
- [x] End-to-end via `swift run IslandCoreCLI local-hooks` + curl on both routes: verified independent sessions, running → waiting → completed → removed
- [ ] Manual: enable in Settings, run a real `codex` turn, watch the island

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Codex CLI local connector using the same localhost hook pipeline as Claude Code, so Codex sessions appear live in the island. Shared plumbing was extracted and Settings now manages both integrations.

- **New Features**
  - `CodexConnector`: maps SessionStart/UserPromptSubmit → running, PermissionRequest → waiting (with tool name), Stop → completed, SessionEnd → removed.
  - `CodexHooksInstaller`: writes `~/.codex/hooks.json` with a fire-and-forget `curl` to `/hooks/codex` on `LocalHookServer` (no `config.toml`; no matcher).
  - `LocalHookServer`: adds `/hooks/codex`; `TaskStore` runs Claude Code + Codex; CLI `local-hooks` reports both (keeps `claude-hooks` alias).
  - Settings: generic local-agent row powers toggles for Claude Code and Codex; TaskCard shows “Cx”.

- **Refactors**
  - Shared internals: `LocalSessionTable` (session bookkeeping + TTL pruning) and `HookConfigEditor` (merge-based JSON edits); Claude installer/connector simplified.
  - Tests/docs: added Codex connector + installer tests; README and interface contract updated.

<sup>Written for commit bfb2c43d6ffdbe78de0cfc7db5afa7796cfb5f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sheepxux/Dev-Island/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

