### PR TITLE
[S] feat: Cursor connector — third local source

### DIFF
--- a/IslandAppLib/Views/Settings/SettingsView.swift
+++ b/IslandAppLib/Views/Settings/SettingsView.swift
@@ -5,8 +5,8 @@ import ServiceManagement
 /// Top-level Settings UI (CLAUDE_CLIENT.md §6 task 6). Three sections:
 ///
 /// - **Connected Services** — Manus row with API key entry + connect/
-///   disconnect controls; Claude Code and Cursor rows show a grayed-out
-///   "Coming Soon" badge per spec.
+///   disconnect controls; Claude Code, Codex and Cursor rows toggle local
+///   hook installation (no API key needed).
 /// - **General** — Launch at Login toggle wired through `SMAppService`.
 /// - **Footer** — Quit button (NSApp.terminate). Closing the window
 ///   alone won't quit, since we're an `.accessory` activation app.
@@ -89,7 +89,14 @@ private struct ConnectedServicesSection: View {
                     uninstall: { try CodexHooksInstaller.uninstall() }
                 )
                 rowDivider
-                ComingSoonRow(name: "Cursor", subtitle: "Editor-side task ingestion")
+                LocalAgentServiceRow(
+                    name: "Cursor",
+                    idleSubtitle: "Track Cursor agent sessions in the island",
+                    configPath: "~/.cursor/hooks.json",
+                    isInstalled: { CursorHooksInstaller.isInstalled() },
+                    install: { try CursorHooksInstaller.install() },
+                    uninstall: { try CursorHooksInstaller.uninstall() }
+                )
             }
             .background(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -235,7 +242,7 @@ private struct ManusServiceRow: View {
     }
 }
 
-// MARK: - Local agent row (Claude Code, Codex)
+// MARK: - Local agent row (Claude Code, Codex, Cursor)
 
 /// Enables/disables a local CLI integration by installing hook entries into
 /// the CLI's config file (via the matching installer). Sessions report their
@@ -297,38 +304,6 @@ private struct LocalAgentServiceRow: View {
         } catch {
             lastError = "Couldn't update \(configPath): \(error.localizedDescription)"
         }
-    }
-}
-
-// MARK: - Coming Soon row
-
-private struct ComingSoonRow: View {
-    let name: String
-    let subtitle: String
-
-    var body: some View {
-        HStack(spacing: 10) {
-            Circle()
-                .fill(Color.secondary.opacity(0.3))
-                .frame(width: 8, height: 8)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(name).font(.system(size: 13, weight: .semibold))
-                Text(subtitle)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            Text("Coming Soon")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(
-                    Capsule().fill(Color.secondary.opacity(0.12))
-                )
-        }
-        .padding(16)
-        .opacity(0.7)
     }
 }
 

--- a/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorConnector.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorConnector.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Tracks Cursor agent conversations as `AgentTask`s.
+///
+/// Event-sourced from hook callbacks delivered by `LocalHookServer`, same
+/// as the Claude Code and Codex connectors. Session bookkeeping lives in
+/// `LocalSessionTable`; this type only supplies the Cursor event vocabulary.
+///
+/// Status mapping:
+///   sessionStart / beforeSubmitPrompt → .running
+///   stop(completed)                   → .completed
+///   stop(aborted)                     → .completed ("Aborted" phase)
+///   stop(error)                       → .failed
+///   sessionEnd                        → session removed
+///
+/// Cursor has no permission-request hook (its gating hooks answer inline),
+/// so unlike Claude/Codex there is no `.waiting` mapping.
+public actor CursorConnector: AgentConnector {
+    public let source = "cursor"
+
+    private var table = LocalSessionTable(source: "cursor", displayName: "Cursor")
+
+    public init() {}
+
+    // MARK: - AgentConnector
+
+    public func fetchTasks() async throws -> [AgentTask] {
+        table.snapshot()
+    }
+
+    nonisolated public func openInBrowser(taskId: String) {
+        // URL opening is handled by TaskStore.openTaskInBrowser(id:).
+    }
+
+    public func stop(taskId: String) async throws {
+        // Local sessions can't be stopped remotely — no-op by design.
+    }
+
+    // MARK: - Event ingestion
+
+    /// Apply one hook event and return the updated task snapshot.
+    public func apply(_ event: CursorEvent, now: Date = .now) -> [AgentTask] {
+        table.prune(now: now)
+
+        guard let id = event.id else { return table.snapshot() }
+
+        switch event.hookEventName {
+        case .sessionStart, .beforeSubmitPrompt:
+            table.upsert(id: id, cwd: event.cwd, now: now) { task in
+                task.status = .running
+                task.currentPhase = nil
+                task.waitingMessage = nil
+            }
+
+        case .stop:
+            table.upsert(id: id, cwd: event.cwd, now: now) { task in
+                switch event.status {
+                case "error":
+                    task.status = .failed
+                    task.currentPhase = "Error"
+                case "aborted":
+                    task.status = .completed
+                    task.currentPhase = "Aborted"
+                default:
+                    task.status = .completed
+                    task.currentPhase = nil
+                }
+                task.waitingMessage = nil
+            }
+
+        case .sessionEnd:
+            table.remove(id: id)
+        }
+
+        return table.snapshot()
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorEvent.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorEvent.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// One lifecycle event emitted by a Cursor hook.
+///
+/// Cursor invokes our hook command (a `curl` one-liner installed into
+/// `~/.cursor/hooks.json`) and pipes a JSON payload on stdin, which the hook
+/// forwards verbatim to `LocalHookServer`. Field names are snake_case —
+/// decode with `.convertFromSnakeCase`.
+///
+/// Unlike Claude Code / Codex, Cursor's event names are camelCase and the
+/// stable session identifier is `conversation_id` (present on every agent
+/// hook); `session_id` appears only on sessionStart / sessionEnd and holds
+/// the same value. The project directory arrives as `workspace_roots`.
+///
+/// Only fire-and-forget events are modeled — we never subscribe to gating
+/// hooks (`beforeShellExecution` etc.), so an empty response from our curl
+/// command can never block a Cursor action. Anything else fails to decode
+/// and is dropped by the server.
+public struct CursorEvent: Decodable, Sendable {
+
+    public enum Kind: String, Decodable, Sendable {
+        case sessionStart
+        case beforeSubmitPrompt
+        case stop
+        case sessionEnd
+    }
+
+    public let hookEventName: Kind
+    /// Stable conversation ID; present on all agent hooks.
+    public let conversationId: String?
+    /// Only on sessionStart / sessionEnd — same value as `conversationId`.
+    public let sessionId: String?
+    /// Workspace root folders (normally exactly one).
+    public let workspaceRoots: [String]?
+    /// `stop` only: "completed" | "aborted" | "error".
+    public let status: String?
+
+    /// The identifier we key sessions by, whichever field carried it.
+    public var id: String? { conversationId ?? sessionId }
+    /// Project directory for the task title / open-in-Finder URL.
+    public var cwd: String? { workspaceRoots?.first }
+
+    public init(
+        hookEventName: Kind,
+        conversationId: String? = nil,
+        sessionId: String? = nil,
+        workspaceRoots: [String]? = nil,
+        status: String? = nil
+    ) {
+        self.hookEventName = hookEventName
+        self.conversationId = conversationId
+        self.sessionId = sessionId
+        self.workspaceRoots = workspaceRoots
+        self.status = status
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorHooksInstaller.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorHooksInstaller.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Installs / removes the Dev Island hook entries in Cursor's user-level
+/// hooks file (`~/.cursor/hooks.json`).
+///
+/// Cursor's format differs from Claude Code / Codex in two ways handled by
+/// `HookConfigEditor`: entries are flat (`{"command": …}`, no nested
+/// `hooks` array, no matcher) and the file requires a top-level
+/// `"version": 1`. Event names are camelCase.
+///
+/// We subscribe only to fire-and-forget lifecycle events — never to gating
+/// hooks — so our command's empty response can't block a Cursor action.
+/// The command itself is fire-and-forget too (`-m 2`, `|| true`, output
+/// discarded): a dead Dev Island can never stall or steer a Cursor turn.
+public enum CursorHooksInstaller {
+
+    /// Hook events we subscribe to. Keep in sync with `CursorEvent.Kind`.
+    static let events = [
+        "sessionStart", "beforeSubmitPrompt", "stop", "sessionEnd",
+    ]
+
+    static let endpointPath = "/hooks/cursor"
+
+    public static func hookCommand(port: Int = ClaudeHooksInstaller.defaultPort) -> String {
+        "curl -sf -m 2 -X POST http://127.0.0.1:\(port)\(endpointPath) "
+            + "-H 'Content-Type: application/json' --data-binary @- >/dev/null 2>&1 || true"
+    }
+
+    public static var defaultHooksURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cursor/hooks.json")
+    }
+
+    // MARK: - Public API
+
+    public static func isInstalled(hooksURL: URL? = nil) -> Bool {
+        HookConfigEditor.isInstalled(
+            at: hooksURL ?? defaultHooksURL,
+            events: events,
+            marker: endpointPath
+        )
+    }
+
+    public static func install(hooksURL: URL? = nil, port: Int = ClaudeHooksInstaller.defaultPort) throws {
+        try HookConfigEditor.install(
+            at: hooksURL ?? defaultHooksURL,
+            events: events,
+            group: ["command": hookCommand(port: port)],
+            marker: endpointPath,
+            rootDefaults: ["version": 1]
+        )
+    }
+
+    public static func uninstall(hooksURL: URL? = nil) throws {
+        try HookConfigEditor.uninstall(
+            at: hooksURL ?? defaultHooksURL,
+            marker: endpointPath
+        )
+    }
+}

--- a/IslandCore/Sources/IslandCore/Connectors/HookConfigEditor.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/HookConfigEditor.swift
@@ -1,9 +1,14 @@
 import Foundation
 
-/// Merge-based editing of hook config files that share the
-/// `{"hooks": {"Event": [{matcher?, hooks: [{type, command}]}]}}` nesting —
-/// Claude Code's `~/.claude/settings.json` and Codex's `~/.codex/hooks.json`
-/// use the identical structure.
+/// Merge-based editing of hook config files that share a
+/// `{"hooks": {"Event": [entry, …]}}` layout. Two entry shapes exist:
+///
+/// - nested (Claude Code `~/.claude/settings.json`, Codex
+///   `~/.codex/hooks.json`): `{matcher?, hooks: [{type, command}]}`
+/// - flat (Cursor `~/.cursor/hooks.json`): `{command}` directly
+///
+/// Both shapes are recognized transparently — an entry is "ours" when its
+/// command string(s) contain the endpoint marker.
 ///
 /// Guarantees:
 /// - unknown top-level keys and user-authored hook groups survive untouched
@@ -21,8 +26,20 @@ enum HookConfigEditor {
         }
     }
 
-    static func install(at url: URL, events: [String], group: [String: Any], marker: String) throws {
+    /// `rootDefaults` are top-level keys written only when absent — e.g.
+    /// Cursor's hooks file requires `"version": 1`, but a user-set value
+    /// must never be overwritten.
+    static func install(
+        at url: URL,
+        events: [String],
+        group: [String: Any],
+        marker: String,
+        rootDefaults: [String: Any] = [:]
+    ) throws {
         var root = readRoot(at: url) ?? [:]
+        for (key, value) in rootDefaults where root[key] == nil {
+            root[key] = value
+        }
         var hooks = root["hooks"] as? [String: Any] ?? [:]
 
         for event in events {
@@ -60,15 +77,16 @@ enum HookConfigEditor {
 
     // MARK: - Private
 
-    /// A matcher group is "ours" when every command in it targets our
-    /// endpoint (user-authored groups are never all-ours).
+    /// An entry is "ours" when every command in it targets our endpoint
+    /// (user-authored entries are never all-ours). Nested entries carry an
+    /// inner `hooks` array; flat entries carry `command` directly.
     private static func isOurGroup(_ group: [String: Any], marker: String) -> Bool {
-        guard let handlers = group["hooks"] as? [[String: Any]], !handlers.isEmpty else {
-            return false
+        if let handlers = group["hooks"] as? [[String: Any]], !handlers.isEmpty {
+            return handlers.allSatisfy { handler in
+                (handler["command"] as? String)?.contains(marker) == true
+            }
         }
-        return handlers.allSatisfy { handler in
-            (handler["command"] as? String)?.contains(marker) == true
-        }
+        return (group["command"] as? String)?.contains(marker) == true
     }
 
     private static func readRoot(at url: URL) -> [String: Any]? {

--- a/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
+++ b/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
@@ -2,7 +2,7 @@ import Foundation
 import Hummingbird
 
 /// Localhost-only HTTP server that receives lifecycle events from local
-/// agent CLIs (Claude Code today; Codex is expected to reuse this).
+/// agent CLIs and editors (Claude Code, Codex, Cursor).
 ///
 /// Deliberately separate from `WebhookServer`: that one is exposed to the
 /// public internet through the cloudflared tunnel for Manus, while this one
@@ -21,7 +21,8 @@ public actor LocalHookServer {
 
     public func start(
         onClaudeCodeEvent: @escaping @Sendable (ClaudeCodeEvent) -> Void,
-        onCodexEvent: @escaping @Sendable (CodexEvent) -> Void
+        onCodexEvent: @escaping @Sendable (CodexEvent) -> Void,
+        onCursorEvent: @escaping @Sendable (CursorEvent) -> Void
     ) {
         serverTask = Task {
             let router = Router()
@@ -36,6 +37,13 @@ public actor LocalHookServer {
             router.post("/hooks/codex") { request, _ -> HTTPResponse.Status in
                 if let event: CodexEvent = await Self.decodeBody(of: request, cli: "Codex") {
                     onCodexEvent(event)
+                }
+                return .ok
+            }
+
+            router.post("/hooks/cursor") { request, _ -> HTTPResponse.Status in
+                if let event: CursorEvent = await Self.decodeBody(of: request, cli: "Cursor") {
+                    onCursorEvent(event)
                 }
                 return .ok
             }

--- a/IslandCore/Sources/IslandCore/TaskStore.swift
+++ b/IslandCore/Sources/IslandCore/TaskStore.swift
@@ -21,12 +21,13 @@ public final class TaskStore {
     private var sqliteStore: SQLiteStore?
     private var pollingOnlyMode = false
 
-    // Local agent pipeline (Claude Code, Codex) — independent of the Manus
-    // API key and of the tunnel/polling lifecycle: it runs for the app's
-    // lifetime.
+    // Local agent pipeline (Claude Code, Codex, Cursor) — independent of the
+    // Manus API key and of the tunnel/polling lifecycle: it runs for the
+    // app's lifetime.
     private var localHookServer: LocalHookServer?
     private var claudeConnector: ClaudeCodeConnector?
     private var codexConnector: CodexConnector?
+    private var cursorConnector: CursorConnector?
 
     private var sleepObserver: NSObjectProtocol?
     private var wakeObserver: NSObjectProtocol?
@@ -170,13 +171,15 @@ public final class TaskStore {
         registerSleepWakeObservers()
     }
 
-    // MARK: - Local agent pipeline (Claude Code)
+    // MARK: - Local agent pipeline (Claude Code, Codex, Cursor)
 
     private func startLocalHookPipeline() {
         let claude = ClaudeCodeConnector()
         claudeConnector = claude
         let codex = CodexConnector()
         codexConnector = codex
+        let cursor = CursorConnector()
+        cursorConnector = cursor
         let server = LocalHookServer()
         localHookServer = server
 
@@ -195,10 +198,17 @@ public final class TaskStore {
                         let snapshot = await codex.apply(event)
                         self.applyLocalSnapshot(source: codex.source, snapshot)
                     }
+                },
+                onCursorEvent: { [weak self] event in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        let snapshot = await cursor.apply(event)
+                        self.applyLocalSnapshot(source: cursor.source, snapshot)
+                    }
                 }
             )
         }
-        IslandLogger.store.info("Local hook pipeline started (claude-code, codex)")
+        IslandLogger.store.info("Local hook pipeline started (claude-code, codex, cursor)")
     }
 
     // MARK: - Service lifecycle

--- a/IslandCoreCLI/Sources/IslandCoreCLI/main.swift
+++ b/IslandCoreCLI/Sources/IslandCoreCLI/main.swift
@@ -12,24 +12,27 @@ import IslandCore
 //   5. Print all received events
 //   6. Cleanup (delete webhook, stop tunnel)
 //
-// Local hooks mode (Claude Code + Codex):
+// Local hooks mode (Claude Code + Codex + Cursor):
 //   swift run IslandCoreCLI local-hooks
-//   Starts LocalHookServer + both local connectors, prints the task snapshot
+//   Starts LocalHookServer + all local connectors, prints the task snapshot
 //   after every event. Exercise it from another terminal, e.g.:
 //     echo '{"session_id":"s1","cwd":"'$PWD'","hook_event_name":"SessionStart"}' \
 //       | curl -sf -m 2 -X POST http://127.0.0.1:7824/hooks/claude-code \
 //              -H 'Content-Type: application/json' --data-binary @-
-//   (same for /hooks/codex)
+//   (same for /hooks/codex; /hooks/cursor uses camelCase event names,
+//    "conversation_id" and "workspace_roots")
 
 if CommandLine.arguments.contains("local-hooks") || CommandLine.arguments.contains("claude-hooks") {
     setvbuf(stdout, nil, _IONBF, 0)  // unbuffered so piped output appears live
     print("[CLI] Local hooks mode — LocalHookServer on 127.0.0.1:\(ClaudeHooksInstaller.defaultPort)")
     print("[CLI] Claude Code hook command: \(ClaudeHooksInstaller.hookCommand())")
     print("[CLI] Codex hook command:       \(CodexHooksInstaller.hookCommand())")
+    print("[CLI] Cursor hook command:      \(CursorHooksInstaller.hookCommand())")
     print("[CLI] Waiting for events (Ctrl+C to stop)...")
 
     let claude = ClaudeCodeConnector()
     let codex = CodexConnector()
+    let cursor = CursorConnector()
     let server = LocalHookServer()
 
     @Sendable func report(_ label: String, _ snapshot: [AgentTask]) {
@@ -52,6 +55,12 @@ if CommandLine.arguments.contains("local-hooks") || CommandLine.arguments.contai
                 Task {
                     let snapshot = await codex.apply(event)
                     report("codex \(event.hookEventName.rawValue) session=\(event.sessionId)", snapshot)
+                }
+            },
+            onCursorEvent: { event in
+                Task {
+                    let snapshot = await cursor.apply(event)
+                    report("cursor \(event.hookEventName.rawValue) session=\(event.id ?? "?")", snapshot)
                 }
             }
         )

--- a/IslandCoreTests/Sources/IslandCoreTests/CursorConnectorTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/CursorConnectorTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class CursorConnectorTests: XCTestCase {
+
+    // MARK: - Event decoding (same decoder config as LocalHookServer)
+
+    private func decode(_ json: String) throws -> CursorEvent {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(CursorEvent.self, from: Data(json.utf8))
+    }
+
+    func testDecodeSessionStart() throws {
+        // sessionStart carries session_id; base fields include conversation_id.
+        let event = try decode("""
+        {"conversation_id":"conv-1","session_id":"conv-1","hook_event_name":"sessionStart","is_background_agent":false,"composer_mode":"agent","cursor_version":"1.7.2","workspace_roots":["/w/Proj"]}
+        """)
+        XCTAssertEqual(event.hookEventName, .sessionStart)
+        XCTAssertEqual(event.id, "conv-1")
+        XCTAssertEqual(event.cwd, "/w/Proj")
+    }
+
+    func testDecodeStopWithStatus() throws {
+        let event = try decode("""
+        {"conversation_id":"conv-1","generation_id":"gen-9","hook_event_name":"stop","status":"error","loop_count":0,"workspace_roots":["/w/Proj"]}
+        """)
+        XCTAssertEqual(event.hookEventName, .stop)
+        XCTAssertEqual(event.status, "error")
+    }
+
+    func testDecodeSessionEndFallsBackToSessionId() throws {
+        // Defensive: key by session_id when conversation_id is absent.
+        let event = try decode("""
+        {"session_id":"conv-1","hook_event_name":"sessionEnd","reason":"user_close","duration_ms":45000}
+        """)
+        XCTAssertEqual(event.id, "conv-1")
+    }
+
+    func testDecodeUnsubscribedEventFails() {
+        XCTAssertThrowsError(try decode("""
+        {"conversation_id":"conv-1","hook_event_name":"beforeShellExecution","command":"git status"}
+        """))
+    }
+
+    // MARK: - Lifecycle mapping
+
+    private func event(
+        _ kind: CursorEvent.Kind,
+        id: String = "conv-1",
+        roots: [String]? = ["/Users/dev/Proj"],
+        status: String? = nil
+    ) -> CursorEvent {
+        CursorEvent(
+            hookEventName: kind,
+            conversationId: id,
+            workspaceRoots: roots,
+            status: status
+        )
+    }
+
+    func testSessionLifecycle() async {
+        let connector = CursorConnector()
+
+        var tasks = await connector.apply(event(.sessionStart))
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].source, "cursor")
+        XCTAssertEqual(tasks[0].status, .running)
+        XCTAssertEqual(tasks[0].title, "Proj")
+        XCTAssertEqual(tasks[0].taskURL, "file:///Users/dev/Proj/")
+
+        tasks = await connector.apply(event(.beforeSubmitPrompt))
+        XCTAssertEqual(tasks[0].status, .running)
+
+        tasks = await connector.apply(event(.stop, status: "completed"))
+        XCTAssertEqual(tasks[0].status, .completed)
+        XCTAssertNil(tasks[0].currentPhase)
+
+        tasks = await connector.apply(event(.sessionEnd))
+        XCTAssertTrue(tasks.isEmpty)
+    }
+
+    func testStopErrorMapsToFailed() async {
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.sessionStart))
+        let tasks = await connector.apply(event(.stop, status: "error"))
+        XCTAssertEqual(tasks[0].status, .failed)
+        XCTAssertEqual(tasks[0].currentPhase, "Error")
+    }
+
+    func testStopAbortedMapsToCompletedWithPhase() async {
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.sessionStart))
+        let tasks = await connector.apply(event(.stop, status: "aborted"))
+        XCTAssertEqual(tasks[0].status, .completed)
+        XCTAssertEqual(tasks[0].currentPhase, "Aborted")
+    }
+
+    func testEventWithoutAnyIdIsIgnored() async {
+        let connector = CursorConnector()
+        let tasks = await connector.apply(
+            CursorEvent(hookEventName: .sessionStart)
+        )
+        XCTAssertTrue(tasks.isEmpty)
+    }
+
+    func testMissingWorkspaceRootsFallsBackToDisplayName() async {
+        let connector = CursorConnector()
+        let tasks = await connector.apply(event(.sessionStart, roots: nil))
+        XCTAssertEqual(tasks[0].title, "Cursor session")
+    }
+
+    func testLocalSourcesAreIndependent() async {
+        // Same session-id string on all three connectors must not collide
+        // at the TaskStore level: sources differ, snapshots are per-source.
+        let codex = CodexConnector()
+        let cursor = CursorConnector()
+        let x1 = await codex.apply(CodexEvent(
+            hookEventName: .sessionStart, sessionId: "s1", cwd: "/a"))
+        let u1 = await cursor.apply(event(.sessionStart, id: "s1", roots: ["/b"]))
+        XCTAssertEqual(x1[0].source, "codex")
+        XCTAssertEqual(u1[0].source, "cursor")
+    }
+}

--- a/IslandCoreTests/Sources/IslandCoreTests/CursorHooksInstallerTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/CursorHooksInstallerTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class CursorHooksInstallerTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var hooksURL: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("island-cursor-hooks-\(UUID().uuidString)")
+        hooksURL = tempDir.appendingPathComponent("hooks.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func readRoot() throws -> [String: Any] {
+        let data = try Data(contentsOf: hooksURL)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: - Tests
+
+    func testInstallIntoMissingFile() throws {
+        XCTAssertFalse(CursorHooksInstaller.isInstalled(hooksURL: hooksURL))
+        try CursorHooksInstaller.install(hooksURL: hooksURL)
+        XCTAssertTrue(CursorHooksInstaller.isInstalled(hooksURL: hooksURL))
+
+        let root = try readRoot()
+        XCTAssertEqual(root["version"] as? Int, 1)  // Cursor requires it
+        let hooks = try XCTUnwrap(root["hooks"] as? [String: Any])
+        XCTAssertEqual(Set(hooks.keys), Set(CursorHooksInstaller.events))
+    }
+
+    func testEntriesAreFlat() throws {
+        // Cursor entries carry `command` directly — no nested `hooks`
+        // array, no matcher wrapper.
+        try CursorHooksInstaller.install(hooksURL: hooksURL)
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        for event in CursorHooksInstaller.events {
+            let entries = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertNotNil(entries[0]["command"] as? String, "flat command missing on \(event)")
+            XCTAssertNil(entries[0]["hooks"], "unexpected nested hooks on \(event)")
+            XCTAssertNil(entries[0]["matcher"], "unexpected matcher on \(event)")
+        }
+    }
+
+    func testInstallPreservesExistingHooksAndVersion() throws {
+        let existing: [String: Any] = [
+            "version": 1,
+            "hooks": [
+                "afterFileEdit": [["command": "./hooks/format.sh"]]
+            ],
+        ]
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: existing).write(to: hooksURL)
+
+        try CursorHooksInstaller.install(hooksURL: hooksURL)
+
+        let root = try readRoot()
+        XCTAssertEqual(root["version"] as? Int, 1)
+        let hooks = try XCTUnwrap(root["hooks"] as? [String: Any])
+        let formatEntries = try XCTUnwrap(hooks["afterFileEdit"] as? [[String: Any]])
+        XCTAssertEqual(formatEntries.count, 1)
+        XCTAssertEqual(formatEntries[0]["command"] as? String, "./hooks/format.sh")
+    }
+
+    func testUserEntryOnSubscribedEventSurvives() throws {
+        let existing: [String: Any] = [
+            "version": 1,
+            "hooks": [
+                "stop": [["command": "./hooks/notify.sh"]]
+            ],
+        ]
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: existing).write(to: hooksURL)
+
+        try CursorHooksInstaller.install(hooksURL: hooksURL)
+        try CursorHooksInstaller.uninstall(hooksURL: hooksURL)
+
+        XCTAssertFalse(CursorHooksInstaller.isInstalled(hooksURL: hooksURL))
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        let stopEntries = try XCTUnwrap(hooks["stop"] as? [[String: Any]])
+        XCTAssertEqual(stopEntries.count, 1)
+        XCTAssertEqual(stopEntries[0]["command"] as? String, "./hooks/notify.sh")
+    }
+
+    func testInstallIsIdempotent() throws {
+        try CursorHooksInstaller.install(hooksURL: hooksURL)
+        try CursorHooksInstaller.install(hooksURL: hooksURL)
+
+        let hooks = try XCTUnwrap(try readRoot()["hooks"] as? [String: Any])
+        for event in CursorHooksInstaller.events {
+            let entries = try XCTUnwrap(hooks[event] as? [[String: Any]])
+            XCTAssertEqual(entries.count, 1, "duplicate entry for \(event)")
+        }
+    }
+
+    func testHookCommandNeverBlocksATurn() {
+        let cmd = CursorHooksInstaller.hookCommand()
+        XCTAssertTrue(cmd.hasSuffix("|| true"))
+        XCTAssertTrue(cmd.contains("-m 2"))
+        XCTAssertTrue(cmd.contains(">/dev/null"))
+        XCTAssertTrue(cmd.contains("/hooks/cursor"))
+    }
+
+    func testSubscribesOnlyToFireAndForgetEvents() {
+        // Gating hooks (beforeShellExecution, preToolUse, …) expect a JSON
+        // permission answer; our silent curl must never be wired to one.
+        let gating = ["beforeShellExecution", "beforeMCPExecution",
+                      "preToolUse", "beforeReadFile", "subagentStart"]
+        for event in gating {
+            XCTAssertFalse(CursorHooksInstaller.events.contains(event))
+        }
+    }
+
+    func testDistinctEndpointsAcrossConnectors() {
+        XCTAssertNotEqual(CursorHooksInstaller.hookCommand(), ClaudeHooksInstaller.hookCommand())
+        XCTAssertNotEqual(CursorHooksInstaller.hookCommand(), CodexHooksInstaller.hookCommand())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ mode you're in.
 | Manus | ✅ Available |
 | Claude Code | ✅ Available (local hooks, no tunnel needed) |
 | Codex CLI | ✅ Available (local hooks, no tunnel needed) |
-| Cursor | 📋 Planned |
+| Cursor | ✅ Available (local hooks, no tunnel needed) |
 
-**Claude Code** and **Codex** need no API key: flip the toggle in
+**Claude Code**, **Codex** and **Cursor** need no API key: flip the toggle in
 *Settings → Connected Services*. Dev Island installs a fire-and-forget hook
-(into `~/.claude/settings.json` / `~/.codex/hooks.json`) that reports session
+(into `~/.claude/settings.json` / `~/.codex/hooks.json` /
+`~/.cursor/hooks.json`) that reports session
 lifecycle events (start / needs-input / approval-request / done / failed) to
 a localhost-only endpoint. New sessions appear in the island within
 milliseconds; clicking one opens the project folder.
@@ -167,7 +168,7 @@ changes go through [`docs/INTERFACE_CONTRACT.md`](docs/INTERFACE_CONTRACT.md).
 | Homebrew Cask tap | 🚧 Draft in `dist/homebrew-island/` |
 | Claude Code connector (local hooks) | ✅ Shipping |
 | Codex connector (local hooks) | ✅ Shipping |
-| Cursor connector | 📋 Next up |
+| Cursor connector (local hooks) | ✅ Shipping |
 
 ## Contributing
 

--- a/docs/INTERFACE_CONTRACT.md
+++ b/docs/INTERFACE_CONTRACT.md
@@ -104,6 +104,32 @@ public enum ClaudeHooksInstaller {
 
 ---
 
+## Codex / Cursor 本地连接器(v1.2.0 / v1.3.0 新增)
+
+API 形态与 Claude Code 完全一致,仅安装器与 source 不同:
+
+```swift
+public enum CodexHooksInstaller {   // 写 ~/.codex/hooks.json
+    public static func isInstalled(hooksURL: URL? = nil) -> Bool
+    public static func install(hooksURL: URL? = nil, port: Int = ClaudeHooksInstaller.defaultPort) throws
+    public static func uninstall(hooksURL: URL? = nil) throws
+}
+
+public enum CursorHooksInstaller {  // 写 ~/.cursor/hooks.json(扁平 entry + 顶层 version: 1)
+    public static func isInstalled(hooksURL: URL? = nil) -> Bool
+    public static func install(hooksURL: URL? = nil, port: Int = ClaudeHooksInstaller.defaultPort) throws
+    public static func uninstall(hooksURL: URL? = nil) throws
+}
+```
+
+行为约定(在 claude-code 约定基础上):
+
+- `source == "codex"`(TaskCard "Cx" logo)/ `source == "cursor"`(TaskCard "Cu" logo)
+- Cursor 只订阅 fire-and-forget 事件,没有 waiting 态;`stop.status == "error"` → failed,`"aborted"` → completed(phase "Aborted")
+- Cursor 的会话键是 `conversation_id`(sessionStart/sessionEnd 上的 `session_id` 值相同)
+
+---
+
 ## 变更记录
 
 | 日期 | 版本 | 描述 | Commit |
@@ -111,3 +137,4 @@ public enum ClaudeHooksInstaller {
 | 2026-04-24 | v1.0.0 | 初始版本 | `[S][contract] feat(store): initial TaskStore API` |
 | 2026-07-28 | v1.1.0 | Claude Code 本地连接器(TaskStore API 不变) | `[S] feat(claude-code): local hooks connector` |
 | 2026-07-28 | v1.2.0 | Codex 本地连接器:`CodexHooksInstaller`(API 形态同 `ClaudeHooksInstaller`,写 `~/.codex/hooks.json`),tasks 新增 `source == "codex"`,其余约定同 claude-code | `[S] feat(codex): local hooks connector` |
+| 2026-07-29 | v1.3.0 | Cursor 本地连接器:`CursorHooksInstaller`(写 `~/.cursor/hooks.json`,扁平 entry + 顶层 `version: 1`),tasks 新增 `source == "cursor"`;仅订阅 fire-and-forget 事件(sessionStart / beforeSubmitPrompt / stop / sessionEnd),无 waiting 态;`stop.status == "error"` 映射为 failed | `[S] feat(cursor): local hooks connector` |


### PR DESCRIPTION
## Summary
- Cursor agent conversations appear in the island via the same localhost pipeline: a fire-and-forget `curl` hook in `~/.cursor/hooks.json` posts stdin JSON to the new `/hooks/cursor` route on `LocalHookServer`
- `CursorConnector` maps sessionStart/beforeSubmitPrompt → running, stop(completed|aborted) → completed, stop(error) → failed, sessionEnd → removed — Cursor's `stop.status` gives us a real failed state the other local connectors don't have
- Subscribes **only** to fire-and-forget events (never gating hooks like `beforeShellExecution`), so our silent curl can never block a Cursor action
- `HookConfigEditor` now recognizes both nested (Claude/Codex) and flat (Cursor) entry shapes, plus a `rootDefaults` param for Cursor's required top-level `"version": 1`
- Settings: Cursor "Coming Soon" row replaced with a live toggle (shared `LocalAgentServiceRow`); TaskCard already had the "Cu" logo

## Test plan
- [x] `swift test` — 81/81 passing (18 new)
- [x] E2E via `swift run IslandCoreCLI local-hooks` + curl: full lifecycle incl. error mapping, and undecodable gating payloads dropped silently
- [ ] Manual: enable in Settings, run a real Cursor agent turn, watch the island

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cursor connector as a third local source so Cursor agent sessions appear in the island via a localhost hook, with a new Settings toggle to install/uninstall the hook.

- **New Features**
  - `CursorConnector` + `CursorEvent`: maps `sessionStart`/`beforeSubmitPrompt` → running, `stop.completed`/`aborted` → completed, `stop.error` → failed, `sessionEnd` → remove.
  - `CursorHooksInstaller`: writes flat `command` entries to ~/.cursor/hooks.json with `"version": 1`; subscribes only to fire-and-forget events; posts stdin JSON to `http://127.0.0.1:<port>/hooks/cursor` and never blocks.
  - `LocalHookServer`: adds `/hooks/cursor`; `TaskStore` integrates Cursor with Claude/Codex; Settings replaces “Coming Soon” with a live toggle; CLI shows the Cursor hook command.
  - Tests, README, and interface docs updated.

<sup>Written for commit 7b1df9f7a3ac29a113d1fbe67df00dbb0c7b083a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sheepxux/Dev-Island/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

