### PR TITLE
[S] feat(core): task transitions + jump-to-session + pipeline hardening (contract v1.4.0, J1+J2)

### DIFF
--- a/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorConnector.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorConnector.swift
@@ -15,10 +15,23 @@ import Foundation
 ///
 /// Cursor has no permission-request hook (its gating hooks answer inline),
 /// so unlike Claude/Codex there is no `.waiting` mapping.
+///
+/// Generation guard: Cursor dispatches hook processes asynchronously, so a
+/// `stop` from an aborted generation can arrive *after* the
+/// `beforeSubmitPrompt` of the next one and would wrongly paint a running
+/// session as "Aborted". We track generations that were explicitly
+/// *superseded* by a newer prompt and drop their late `stop`s. Unknown
+/// generations always apply — generation IDs aren't ordered, so "not yet
+/// superseded" is the only safe staleness signal (a legit `stop` may even
+/// outrace its own `beforeSubmitPrompt`).
 public actor CursorConnector: AgentConnector {
     public let source = "cursor"
 
     private var table = LocalSessionTable(source: "cursor", displayName: "Cursor")
+    /// Latest generation seen per session (from beforeSubmitPrompt).
+    private var currentGeneration: [String: String] = [:]
+    /// Generations replaced by a newer prompt; their stops are stale.
+    private var supersededGenerations: [String: Set<String>] = [:]
 
     public init() {}
 
@@ -46,6 +59,12 @@ public actor CursorConnector: AgentConnector {
 
         switch event.hookEventName {
         case .sessionStart, .beforeSubmitPrompt:
+            if event.hookEventName == .beforeSubmitPrompt, let generation = event.generationId {
+                if let previous = currentGeneration[id], previous != generation {
+                    supersededGenerations[id, default: []].insert(previous)
+                }
+                currentGeneration[id] = generation
+            }
             table.upsert(id: id, cwd: event.cwd, now: now) { task in
                 task.status = .running
                 task.currentPhase = nil
@@ -53,6 +72,12 @@ public actor CursorConnector: AgentConnector {
             }
 
         case .stop:
+            // Drop stale stops from a superseded generation (see actor doc).
+            if let generation = event.generationId,
+               supersededGenerations[id]?.contains(generation) == true {
+                IslandLogger.webhook.debug("Cursor: dropping stale stop (superseded generation)")
+                break
+            }
             table.upsert(id: id, cwd: event.cwd, now: now) { task in
                 switch event.status {
                 case "error":
@@ -70,6 +95,8 @@ public actor CursorConnector: AgentConnector {
 
         case .sessionEnd:
             table.remove(id: id)
+            currentGeneration.removeValue(forKey: id)
+            supersededGenerations.removeValue(forKey: id)
         }
 
         return table.snapshot()

--- a/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorConnector.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorConnector.swift
@@ -16,22 +16,37 @@ import Foundation
 /// Cursor has no permission-request hook (its gating hooks answer inline),
 /// so unlike Claude/Codex there is no `.waiting` mapping.
 ///
-/// Generation guard: Cursor dispatches hook processes asynchronously, so a
-/// `stop` from an aborted generation can arrive *after* the
-/// `beforeSubmitPrompt` of the next one and would wrongly paint a running
-/// session as "Aborted". We track generations that were explicitly
-/// *superseded* by a newer prompt and drop their late `stop`s. Unknown
-/// generations always apply — generation IDs aren't ordered, so "not yet
-/// superseded" is the only safe staleness signal (a legit `stop` may even
-/// outrace its own `beforeSubmitPrompt`).
+/// Generation guard: Cursor dispatches hook processes asynchronously, so
+/// events can arrive out of order. Two races are handled:
+///
+/// 1. A `stop` from an aborted generation arrives *after* the
+///    `beforeSubmitPrompt` of the next one and would wrongly paint a
+///    running session as "Aborted" → generations explicitly *superseded*
+///    by a newer prompt have their late `stop`s dropped.
+/// 2. A `stop` outraces its own `beforeSubmitPrompt`; the late prompt
+///    would resurrect a finished generation as `.running` → generations
+///    that already stopped are remembered and their late prompts ignored.
+///
+/// Unknown generations always apply — generation IDs aren't ordered, so
+/// "not yet superseded" is the only safe staleness signal. Known accepted
+/// limitation: two *prompts* delivered in reverse order could mark the
+/// newer generation superseded; not guarded because prompt emissions are
+/// human-sequenced seconds apart while delivery jitter is milliseconds.
 public actor CursorConnector: AgentConnector {
     public let source = "cursor"
+
+    /// Per-session bookkeeping caps so a pathological long-lived session
+    /// can't grow memory unboundedly; evicting (unordered) extras only
+    /// degrades the guard back to "apply everything", never corrupts state.
+    private static let maxTrackedGenerations = 64
 
     private var table = LocalSessionTable(source: "cursor", displayName: "Cursor")
     /// Latest generation seen per session (from beforeSubmitPrompt).
     private var currentGeneration: [String: String] = [:]
     /// Generations replaced by a newer prompt; their stops are stale.
     private var supersededGenerations: [String: Set<String>] = [:]
+    /// Generations that already received a stop; their prompts are stale.
+    private var stoppedGenerations: [String: Set<String>] = [:]
 
     public init() {}
 
@@ -54,14 +69,21 @@ public actor CursorConnector: AgentConnector {
     /// Apply one hook event and return the updated task snapshot.
     public func apply(_ event: CursorEvent, now: Date = .now) -> [AgentTask] {
         table.prune(now: now)
+        pruneBookkeeping()
 
         guard let id = event.id else { return table.snapshot() }
 
         switch event.hookEventName {
         case .sessionStart, .beforeSubmitPrompt:
             if event.hookEventName == .beforeSubmitPrompt, let generation = event.generationId {
+                // Race 2: this generation already stopped — don't resurrect
+                // it as running (its stop outraced this prompt).
+                if stoppedGenerations[id]?.contains(generation) == true {
+                    IslandLogger.webhook.debug("Cursor: dropping stale prompt (generation already stopped)")
+                    break
+                }
                 if let previous = currentGeneration[id], previous != generation {
-                    supersededGenerations[id, default: []].insert(previous)
+                    insertCapped(&supersededGenerations[id, default: []], previous)
                 }
                 currentGeneration[id] = generation
             }
@@ -72,11 +94,13 @@ public actor CursorConnector: AgentConnector {
             }
 
         case .stop:
-            // Drop stale stops from a superseded generation (see actor doc).
-            if let generation = event.generationId,
-               supersededGenerations[id]?.contains(generation) == true {
-                IslandLogger.webhook.debug("Cursor: dropping stale stop (superseded generation)")
-                break
+            if let generation = event.generationId {
+                insertCapped(&stoppedGenerations[id, default: []], generation)
+                // Race 1: drop stale stops from a superseded generation.
+                if supersededGenerations[id]?.contains(generation) == true {
+                    IslandLogger.webhook.debug("Cursor: dropping stale stop (superseded generation)")
+                    break
+                }
             }
             table.upsert(id: id, cwd: event.cwd, now: now) { task in
                 switch event.status {
@@ -97,8 +121,27 @@ public actor CursorConnector: AgentConnector {
             table.remove(id: id)
             currentGeneration.removeValue(forKey: id)
             supersededGenerations.removeValue(forKey: id)
+            stoppedGenerations.removeValue(forKey: id)
         }
 
         return table.snapshot()
+    }
+
+    // MARK: - Bookkeeping hygiene
+
+    /// Drop generation bookkeeping for sessions the table no longer tracks
+    /// (TTL-pruned or crashed without a sessionEnd).
+    private func pruneBookkeeping() {
+        let live = Set(table.snapshot().map(\.id))
+        currentGeneration = currentGeneration.filter { live.contains($0.key) }
+        supersededGenerations = supersededGenerations.filter { live.contains($0.key) }
+        stoppedGenerations = stoppedGenerations.filter { live.contains($0.key) }
+    }
+
+    private func insertCapped(_ set: inout Set<String>, _ member: String) {
+        set.insert(member)
+        while set.count > Self.maxTrackedGenerations {
+            set.removeFirst()
+        }
     }
 }

--- a/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorEvent.swift
+++ b/IslandCore/Sources/IslandCore/Connectors/Cursor/CursorEvent.swift
@@ -30,6 +30,10 @@ public struct CursorEvent: Decodable, Sendable {
     public let conversationId: String?
     /// Only on sessionStart / sessionEnd — same value as `conversationId`.
     public let sessionId: String?
+    /// Changes with every user message. Used to drop stale, out-of-order
+    /// `stop` events (hook processes are dispatched async, delivery order
+    /// is not guaranteed).
+    public let generationId: String?
     /// Workspace root folders (normally exactly one).
     public let workspaceRoots: [String]?
     /// `stop` only: "completed" | "aborted" | "error".
@@ -44,12 +48,14 @@ public struct CursorEvent: Decodable, Sendable {
         hookEventName: Kind,
         conversationId: String? = nil,
         sessionId: String? = nil,
+        generationId: String? = nil,
         workspaceRoots: [String]? = nil,
         status: String? = nil
     ) {
         self.hookEventName = hookEventName
         self.conversationId = conversationId
         self.sessionId = sessionId
+        self.generationId = generationId
         self.workspaceRoots = workspaceRoots
         self.status = status
     }

--- a/IslandCore/Sources/IslandCore/Internal/SourceAppResolver.swift
+++ b/IslandCore/Sources/IslandCore/Internal/SourceAppResolver.swift
@@ -1,0 +1,58 @@
+import AppKit
+
+/// Resolves which running application to activate for "jump back to the
+/// session" (contract v1.4.0, J2 — `TaskStore.jumpToTask`).
+///
+/// Strategy is deliberately app-level, not window-level: macOS gives us no
+/// sanctioned way to find *which* terminal window hosts a given CLI session
+/// without Accessibility permissions, so v1 activates the most plausible
+/// host app and lets the user land on their last-used window.
+enum SourceAppResolver {
+
+    /// Terminal emulators that commonly host CLI agents, ordered by how
+    /// likely a developer is to have exactly one of them as their daily
+    /// driver. Only *running* apps are considered, so order rarely matters
+    /// in practice.
+    private static let terminalCandidates = [
+        "com.googlecode.iterm2",         // iTerm2
+        "com.mitchellh.ghostty",         // Ghostty
+        "dev.warp.Warp-Stable",          // Warp
+        "net.kovidgoyal.kitty",          // kitty
+        "org.alacritty",                 // Alacritty
+        "com.github.wez.wezterm",        // WezTerm
+        "com.apple.Terminal",            // Terminal.app (last: everyone has it)
+    ]
+
+    /// Candidate bundle IDs per task source, most specific first.
+    static func candidates(for source: String) -> [String] {
+        switch source {
+        case "cursor":
+            return ["com.todesktop.230313mzl4w4u92"]  // Cursor.app
+        case "codex":
+            // Codex Desktop first; CLI sessions live in a terminal.
+            return ["com.openai.codex"] + terminalCandidates
+        case "claude-code":
+            return terminalCandidates
+        default:
+            return []  // manus & friends: no local app — caller falls back
+        }
+    }
+
+    /// Pure resolution step, unit-testable: pick the first candidate that
+    /// is actually running.
+    static func resolveBundleId(source: String, running: Set<String>) -> String? {
+        candidates(for: source).first(where: running.contains)
+    }
+
+    /// Activate the resolved app. Returns false when nothing suitable is
+    /// running (caller falls back to `openTaskInBrowser` behavior).
+    @MainActor
+    static func activateApp(for source: String) -> Bool {
+        let apps = NSWorkspace.shared.runningApplications
+        let running = Set(apps.compactMap(\.bundleIdentifier))
+        guard let bundleId = resolveBundleId(source: source, running: running),
+              let app = apps.first(where: { $0.bundleIdentifier == bundleId })
+        else { return false }
+        return app.activate()
+    }
+}

--- a/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
+++ b/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
@@ -11,9 +11,27 @@ import Hummingbird
 ///
 /// Always returns 200 (even for undecodable bodies) so a hook misfire can
 /// never surface as an error inside the user's Claude Code session.
+///
+/// Resilience: a failed serve loop (typically "address already in use" from
+/// a lingering process) no longer dies silently — it retries with backoff a
+/// bounded number of times, and `ensureRunning()` (called on system wake)
+/// re-arms a server that exhausted its retries.
 public actor LocalHookServer {
     public let port: Int
-    private var serverTask: Task<Void, Error>?
+
+    private struct Handlers {
+        let onClaudeCode: @Sendable (ClaudeCodeEvent) -> Void
+        let onCodex: @Sendable (CodexEvent) -> Void
+        let onCursor: @Sendable (CursorEvent) -> Void
+    }
+
+    private static let maxConsecutiveFailures = 5
+
+    private var handlers: Handlers?
+    private var serverTask: Task<Void, Never>?
+    private var consecutiveFailures = 0
+    /// True while a serve loop (or its retry backoff) is in flight.
+    private var isServing = false
 
     public init(port: Int = ClaudeHooksInstaller.defaultPort) {
         self.port = port
@@ -24,37 +42,108 @@ public actor LocalHookServer {
         onCodexEvent: @escaping @Sendable (CodexEvent) -> Void,
         onCursorEvent: @escaping @Sendable (CursorEvent) -> Void
     ) {
+        handlers = Handlers(
+            onClaudeCode: onClaudeCodeEvent,
+            onCodex: onCodexEvent,
+            onCursor: onCursorEvent
+        )
+        consecutiveFailures = 0
+        launchServeLoop()
+    }
+
+    /// Health check for the wake path: relaunch if the serve loop died
+    /// (e.g. port was busy at boot and retries ran out; the offender is
+    /// often gone by the time the machine wakes again).
+    public func ensureRunning() {
+        guard handlers != nil, !isServing else { return }
+        IslandLogger.webhook.info("LocalHookServer health check: serve loop dead — relaunching")
+        consecutiveFailures = 0
+        launchServeLoop()
+    }
+
+    public func stop() {
+        serverTask?.cancel()
+        serverTask = nil
+        handlers = nil
+        isServing = false
+        IslandLogger.webhook.info("LocalHookServer stopped")
+    }
+
+    // MARK: - Serve loop
+
+    private func launchServeLoop() {
+        guard let handlers else { return }
+        isServing = true
         serverTask = Task {
-            let router = Router()
-
-            router.post("/hooks/claude-code") { request, _ -> HTTPResponse.Status in
-                if let event: ClaudeCodeEvent = await Self.decodeBody(of: request, cli: "Claude Code") {
-                    onClaudeCodeEvent(event)
-                }
-                return .ok
+            do {
+                try await Self.serve(port: port, handlers: handlers)
+                // app.run() only returns on graceful shutdown.
+                self.markStopped()
+            } catch is CancellationError {
+                self.markStopped()
+            } catch {
+                await self.handleServeFailure(error)
             }
-
-            router.post("/hooks/codex") { request, _ -> HTTPResponse.Status in
-                if let event: CodexEvent = await Self.decodeBody(of: request, cli: "Codex") {
-                    onCodexEvent(event)
-                }
-                return .ok
-            }
-
-            router.post("/hooks/cursor") { request, _ -> HTTPResponse.Status in
-                if let event: CursorEvent = await Self.decodeBody(of: request, cli: "Cursor") {
-                    onCursorEvent(event)
-                }
-                return .ok
-            }
-
-            let app = Application(
-                router: router,
-                configuration: .init(address: .hostname("127.0.0.1", port: self.port))
-            )
-            IslandLogger.webhook.info("LocalHookServer listening on 127.0.0.1:\(self.port)")
-            try await app.run()
         }
+    }
+
+    private func markStopped() {
+        isServing = false
+    }
+
+    private func handleServeFailure(_ error: Error) async {
+        consecutiveFailures += 1
+        guard consecutiveFailures <= Self.maxConsecutiveFailures else {
+            isServing = false
+            IslandLogger.webhook.error("""
+                LocalHookServer gave up after \(Self.maxConsecutiveFailures) failures \
+                (last: \(error)). Port \(self.port) likely held by another process. \
+                Will retry on next wake.
+                """)
+            return
+        }
+        let delay = min(30, consecutiveFailures * 5)
+        IslandLogger.webhook.error(
+            "LocalHookServer serve loop failed (\(error)) — retry \(self.consecutiveFailures)/\(Self.maxConsecutiveFailures) in \(delay)s"
+        )
+        try? await Task.sleep(for: .seconds(delay))
+        guard !Task.isCancelled, handlers != nil else {
+            isServing = false
+            return
+        }
+        launchServeLoop()
+    }
+
+    private static func serve(port: Int, handlers: Handlers) async throws {
+        let router = Router()
+
+        router.post("/hooks/claude-code") { request, _ -> HTTPResponse.Status in
+            if let event: ClaudeCodeEvent = await Self.decodeBody(of: request, cli: "Claude Code") {
+                handlers.onClaudeCode(event)
+            }
+            return .ok
+        }
+
+        router.post("/hooks/codex") { request, _ -> HTTPResponse.Status in
+            if let event: CodexEvent = await Self.decodeBody(of: request, cli: "Codex") {
+                handlers.onCodex(event)
+            }
+            return .ok
+        }
+
+        router.post("/hooks/cursor") { request, _ -> HTTPResponse.Status in
+            if let event: CursorEvent = await Self.decodeBody(of: request, cli: "Cursor") {
+                handlers.onCursor(event)
+            }
+            return .ok
+        }
+
+        let app = Application(
+            router: router,
+            configuration: .init(address: .hostname("127.0.0.1", port: port))
+        )
+        IslandLogger.webhook.info("LocalHookServer listening on 127.0.0.1:\(port)")
+        try await app.run()
     }
 
     /// Decode a snake_case hook payload; undecodable bodies are dropped
@@ -71,11 +160,5 @@ public actor LocalHookServer {
         }
         IslandLogger.webhook.info("\(cli) hook event received")
         return event
-    }
-
-    public func stop() {
-        serverTask?.cancel()
-        serverTask = nil
-        IslandLogger.webhook.info("LocalHookServer stopped")
     }
 }

--- a/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
+++ b/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
@@ -79,12 +79,21 @@ public actor LocalHookServer {
 
     // MARK: - Serve loop
 
+    private func currentEpoch() -> Int { epoch }
+
     private func launchServeLoop(epoch: Int) {
         guard epoch == self.epoch, let handlers else { return }
         isServing = true
+        // Route closures re-check this before delivering: a superseded serve
+        // loop may still be draining in-flight requests after cancellation
+        // (cancel is non-awaiting), and those must not reach the handlers.
+        let isLive: @Sendable () async -> Bool = { [weak self] in
+            guard let self else { return false }
+            return await self.currentEpoch() == epoch
+        }
         serverTask = Task {
             do {
-                try await Self.serve(port: port, handlers: handlers)
+                try await Self.serve(port: port, handlers: handlers, isLive: isLive)
                 // app.run() only returns on graceful shutdown.
                 self.markStopped(epoch: epoch)
             } catch is CancellationError {
@@ -124,25 +133,32 @@ public actor LocalHookServer {
         launchServeLoop(epoch: epoch)
     }
 
-    private static func serve(port: Int, handlers: Handlers) async throws {
+    private static func serve(
+        port: Int,
+        handlers: Handlers,
+        isLive: @escaping @Sendable () async -> Bool
+    ) async throws {
         let router = Router()
 
         router.post("/hooks/claude-code") { request, _ -> HTTPResponse.Status in
-            if let event: ClaudeCodeEvent = await Self.decodeBody(of: request, cli: "Claude Code") {
+            if let event: ClaudeCodeEvent = await Self.decodeBody(of: request, cli: "Claude Code"),
+               await isLive() {
                 handlers.onClaudeCode(event)
             }
             return .ok
         }
 
         router.post("/hooks/codex") { request, _ -> HTTPResponse.Status in
-            if let event: CodexEvent = await Self.decodeBody(of: request, cli: "Codex") {
+            if let event: CodexEvent = await Self.decodeBody(of: request, cli: "Codex"),
+               await isLive() {
                 handlers.onCodex(event)
             }
             return .ok
         }
 
         router.post("/hooks/cursor") { request, _ -> HTTPResponse.Status in
-            if let event: CursorEvent = await Self.decodeBody(of: request, cli: "Cursor") {
+            if let event: CursorEvent = await Self.decodeBody(of: request, cli: "Cursor"),
+               await isLive() {
                 handlers.onCursor(event)
             }
             return .ok

--- a/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
+++ b/IslandCore/Sources/IslandCore/LocalHooks/LocalHookServer.swift
@@ -25,6 +25,7 @@ public actor LocalHookServer {
         let onCursor: @Sendable (CursorEvent) -> Void
     }
 
+    /// Total serve attempts per arming (1 initial + 4 retries).
     private static let maxConsecutiveFailures = 5
 
     private var handlers: Handlers?
@@ -32,6 +33,9 @@ public actor LocalHookServer {
     private var consecutiveFailures = 0
     /// True while a serve loop (or its retry backoff) is in flight.
     private var isServing = false
+    /// Lifecycle token: bumped on every start/stop/re-arm so callbacks from
+    /// a cancelled serve loop can never mutate the state of its successor.
+    private var epoch = 0
 
     public init(port: Int = ClaudeHooksInstaller.defaultPort) {
         self.port = port
@@ -42,13 +46,15 @@ public actor LocalHookServer {
         onCodexEvent: @escaping @Sendable (CodexEvent) -> Void,
         onCursorEvent: @escaping @Sendable (CursorEvent) -> Void
     ) {
+        epoch += 1
+        serverTask?.cancel()
         handlers = Handlers(
             onClaudeCode: onClaudeCodeEvent,
             onCodex: onCodexEvent,
             onCursor: onCursorEvent
         )
         consecutiveFailures = 0
-        launchServeLoop()
+        launchServeLoop(epoch: epoch)
     }
 
     /// Health check for the wake path: relaunch if the serve loop died
@@ -57,11 +63,13 @@ public actor LocalHookServer {
     public func ensureRunning() {
         guard handlers != nil, !isServing else { return }
         IslandLogger.webhook.info("LocalHookServer health check: serve loop dead — relaunching")
+        epoch += 1
         consecutiveFailures = 0
-        launchServeLoop()
+        launchServeLoop(epoch: epoch)
     }
 
     public func stop() {
+        epoch += 1
         serverTask?.cancel()
         serverTask = nil
         handlers = nil
@@ -71,32 +79,34 @@ public actor LocalHookServer {
 
     // MARK: - Serve loop
 
-    private func launchServeLoop() {
-        guard let handlers else { return }
+    private func launchServeLoop(epoch: Int) {
+        guard epoch == self.epoch, let handlers else { return }
         isServing = true
         serverTask = Task {
             do {
                 try await Self.serve(port: port, handlers: handlers)
                 // app.run() only returns on graceful shutdown.
-                self.markStopped()
+                self.markStopped(epoch: epoch)
             } catch is CancellationError {
-                self.markStopped()
+                self.markStopped(epoch: epoch)
             } catch {
-                await self.handleServeFailure(error)
+                await self.handleServeFailure(error, epoch: epoch)
             }
         }
     }
 
-    private func markStopped() {
+    private func markStopped(epoch: Int) {
+        guard epoch == self.epoch else { return }
         isServing = false
     }
 
-    private func handleServeFailure(_ error: Error) async {
+    private func handleServeFailure(_ error: Error, epoch: Int) async {
+        guard epoch == self.epoch else { return }
         consecutiveFailures += 1
-        guard consecutiveFailures <= Self.maxConsecutiveFailures else {
+        guard consecutiveFailures < Self.maxConsecutiveFailures else {
             isServing = false
             IslandLogger.webhook.error("""
-                LocalHookServer gave up after \(Self.maxConsecutiveFailures) failures \
+                LocalHookServer gave up after \(self.consecutiveFailures) failed attempts \
                 (last: \(error)). Port \(self.port) likely held by another process. \
                 Will retry on next wake.
                 """)
@@ -104,14 +114,14 @@ public actor LocalHookServer {
         }
         let delay = min(30, consecutiveFailures * 5)
         IslandLogger.webhook.error(
-            "LocalHookServer serve loop failed (\(error)) — retry \(self.consecutiveFailures)/\(Self.maxConsecutiveFailures) in \(delay)s"
+            "LocalHookServer serve loop failed (\(error)) — attempt \(self.consecutiveFailures)/\(Self.maxConsecutiveFailures), retrying in \(delay)s"
         )
         try? await Task.sleep(for: .seconds(delay))
-        guard !Task.isCancelled, handlers != nil else {
-            isServing = false
+        guard epoch == self.epoch, !Task.isCancelled, handlers != nil else {
+            markStopped(epoch: epoch)
             return
         }
-        launchServeLoop()
+        launchServeLoop(epoch: epoch)
     }
 
     private static func serve(port: Int, handlers: Handlers) async throws {

--- a/IslandCore/Sources/IslandCore/Models/TaskTransition.swift
+++ b/IslandCore/Sources/IslandCore/Models/TaskTransition.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// One task status transition, delivered through `TaskStore.onTaskTransition`
+/// (contract v1.4.0, J1). B side maps these to user notifications.
+public struct TaskTransition: Sendable {
+    /// The task *after* the transition.
+    public let task: AgentTask
+    /// Status before the transition; `nil` means the task appeared for the
+    /// first time (B should usually not notify on these — startup snapshots
+    /// would spam).
+    public let oldStatus: TaskStatus?
+    /// Same as `task.status`, duplicated for ergonomic `switch`ing.
+    public let newStatus: TaskStatus
+
+    public init(task: AgentTask, oldStatus: TaskStatus?, newStatus: TaskStatus) {
+        self.task = task
+        self.oldStatus = oldStatus
+        self.newStatus = newStatus
+    }
+}
+
+extension TaskTransition {
+    /// Diff two task lists into the transitions the contract promises:
+    /// one per task whose status changed, `oldStatus == nil` for newly
+    /// appeared tasks, nothing for removals. Order follows `new`.
+    ///
+    /// Tasks are keyed by (source, id) — session ids are only unique per
+    /// source (the same CLI session-id string can legally exist on two
+    /// different connectors).
+    static func diff(old: [AgentTask], new: [AgentTask]) -> [TaskTransition] {
+        var oldStatuses: [String: TaskStatus] = [:]
+        for task in old {
+            oldStatuses["\(task.source)#\(task.id)"] = task.status
+        }
+        return new.compactMap { task in
+            let oldStatus = oldStatuses["\(task.source)#\(task.id)"]
+            guard oldStatus != task.status else { return nil }
+            return TaskTransition(task: task, oldStatus: oldStatus, newStatus: task.status)
+        }
+    }
+}

--- a/IslandCore/Sources/IslandCore/Models/TaskTransition.swift
+++ b/IslandCore/Sources/IslandCore/Models/TaskTransition.swift
@@ -10,12 +10,13 @@ public struct TaskTransition: Sendable {
     /// would spam).
     public let oldStatus: TaskStatus?
     /// Same as `task.status`, duplicated for ergonomic `switch`ing.
+    /// Derived in the initializer so the two can never disagree.
     public let newStatus: TaskStatus
 
-    public init(task: AgentTask, oldStatus: TaskStatus?, newStatus: TaskStatus) {
+    public init(task: AgentTask, oldStatus: TaskStatus?) {
         self.task = task
         self.oldStatus = oldStatus
-        self.newStatus = newStatus
+        self.newStatus = task.status
     }
 }
 
@@ -28,14 +29,18 @@ extension TaskTransition {
     /// source (the same CLI session-id string can legally exist on two
     /// different connectors).
     static func diff(old: [AgentTask], new: [AgentTask]) -> [TaskTransition] {
-        var oldStatuses: [String: TaskStatus] = [:]
+        struct Key: Hashable {
+            let source: String
+            let id: String
+        }
+        var oldStatuses: [Key: TaskStatus] = [:]
         for task in old {
-            oldStatuses["\(task.source)#\(task.id)"] = task.status
+            oldStatuses[Key(source: task.source, id: task.id)] = task.status
         }
         return new.compactMap { task in
-            let oldStatus = oldStatuses["\(task.source)#\(task.id)"]
+            let oldStatus = oldStatuses[Key(source: task.source, id: task.id)]
             guard oldStatus != task.status else { return nil }
-            return TaskTransition(task: task, oldStatus: oldStatus, newStatus: task.status)
+            return TaskTransition(task: task, oldStatus: oldStatus)
         }
     }
 }

--- a/IslandCore/Sources/IslandCore/TaskStore.swift
+++ b/IslandCore/Sources/IslandCore/TaskStore.swift
@@ -13,6 +13,13 @@ public final class TaskStore {
     public private(set) var connectionStatus: ConnectionStatus = .disconnected
     public private(set) var apiKeyStatus: APIKeyStatus = .notConfigured
 
+    /// Task status-transition callback (contract v1.4.0, J1). B side assigns
+    /// once at app startup and maps transitions to notifications.
+    /// Fires on the main actor after `tasks` is already updated; one call per
+    /// changed task; newly appeared tasks fire with `oldStatus == nil`;
+    /// removals don't fire. Debug mutators fire too (Debug Sandbox testing).
+    public var onTaskTransition: ((TaskTransition) -> Void)?
+
     // MARK: - Private internals
 
     private var connectors: [any AgentConnector] = []
@@ -34,8 +41,25 @@ public final class TaskStore {
 
     // MARK: - Init
 
-    private init() {
-        Task { await bootstrap() }
+    /// `bootstrap: false` builds an inert store (previews / unit tests) that
+    /// never touches SQLite, Keychain, or the local hook server.
+    private init(bootstrap: Bool = true) {
+        if bootstrap {
+            Task { await self.bootstrap() }
+        }
+    }
+
+    // MARK: - Task mutation funnel
+
+    /// Every `tasks` write goes through here so status transitions are
+    /// detected exactly once, in one place (contract v1.4.0).
+    private func setTasks(_ newTasks: [AgentTask]) {
+        let transitions = TaskTransition.diff(old: tasks, new: newTasks)
+        tasks = newTasks
+        guard let onTaskTransition else { return }
+        for transition in transitions {
+            onTaskTransition(transition)
+        }
     }
 
     // MARK: - Public API
@@ -62,7 +86,7 @@ public final class TaskStore {
         try? KeychainStore.delete()
         // Only Manus tasks belong to the API key — local agent sessions
         // (Claude Code) are unaffected by a disconnect.
-        tasks = tasks.filter { $0.source != "manus" }
+        setTasks(tasks.filter { $0.source != "manus" })
         apiKeyStatus = .notConfigured
         connectionStatus = .disconnected
         IslandLogger.store.info("API key cleared")
@@ -74,6 +98,20 @@ public final class TaskStore {
         NSWorkspace.shared.open(url)
     }
 
+    /// Jump back to the session behind a task (contract v1.4.0, J2).
+    /// App-level activation of the source app (cursor → Cursor.app,
+    /// codex → Codex Desktop or a running terminal, claude-code → a running
+    /// terminal); falls back to `openTaskInBrowser` behavior when no
+    /// suitable app is running (local tasks → Finder, Manus → browser).
+    public func jumpToTask(id: String) {
+        guard let task = tasks.first(where: { $0.id == id }) else { return }
+        if SourceAppResolver.activateApp(for: task.source) {
+            IslandLogger.store.debug("jumpToTask(\(id)): activated \(task.source) host app")
+            return
+        }
+        openTaskInBrowser(id: id)
+    }
+
     public func stopTask(id: String) async throws {
         guard let task = tasks.first(where: { $0.id == id }) else { return }
         // Only Manus tasks can be stopped remotely; local sessions
@@ -81,19 +119,19 @@ public final class TaskStore {
         guard task.source == "manus", let connector = connectors.first else { return }
         try await connector.stop(taskId: id)
         // Optimistically update status
-        tasks = tasks.map { t in
+        setTasks(tasks.map { t in
             guard t.id == id else { return t }
             var updated = t
             updated.status = .completed
             updated.updatedAt = Date.now
             return updated
-        }
+        })
     }
 
     // MARK: - Internal (called by TunnelManager / PollingFallback)
 
     internal func ingestWebhookEvent(_ event: WebhookPayload) {
-        tasks = StateReconciler.apply(event: event, to: tasks)
+        setTasks(StateReconciler.apply(event: event, to: tasks))
         // Write to SQLite in background (best-effort)
         let store = sqliteStore
         Task.detached {
@@ -111,7 +149,7 @@ public final class TaskStore {
     internal func applyPollingSnapshot(_ incoming: [AgentTask]) {
         // Polling only covers Manus — scope the reconcile so local agent
         // sessions (claude-code) survive the snapshot merge.
-        tasks = StateReconciler.reconcile(local: tasks, incoming: incoming, source: "manus")
+        setTasks(StateReconciler.reconcile(local: tasks, incoming: incoming, source: "manus"))
         let store = sqliteStore
         let snapshot = tasks.filter { $0.source == "manus" }
         Task.detached {
@@ -125,7 +163,7 @@ public final class TaskStore {
     /// Replace all tasks of one local source with a fresh snapshot from its
     /// connector (event-sourced, so the connector state is authoritative).
     internal func applyLocalSnapshot(source: String, _ snapshot: [AgentTask]) {
-        tasks = tasks.filter { $0.source != source } + snapshot
+        setTasks(tasks.filter { $0.source != source } + snapshot)
     }
 
     // MARK: - Bootstrap
@@ -138,6 +176,11 @@ public final class TaskStore {
 
         // Local agent pipeline runs regardless of Manus configuration.
         startLocalHookPipeline()
+
+        // Sleep/wake observers guard the local pipeline too, so they must
+        // register even when no Manus key is configured (previously they
+        // were only registered at the end of the happy path).
+        registerSleepWakeObservers()
 
         // Load API key from Keychain
         guard let apiKey = try? KeychainStore.load() else {
@@ -167,8 +210,6 @@ public final class TaskStore {
             IslandLogger.store.error("Failed to start services: \(error)")
             connectionStatus = .degraded(reason: error.localizedDescription)
         }
-
-        registerSleepWakeObservers()
     }
 
     // MARK: - Local agent pipeline (Claude Code, Codex, Cursor)
@@ -307,8 +348,13 @@ public final class TaskStore {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                IslandLogger.store.info("System woke — health-checking services")
+                // Local pipeline first: relaunch the hook server if its
+                // serve loop died while we slept (e.g. transient bind error).
+                await self.localHookServer?.ensureRunning()
+                // Manus side only applies when services are configured.
+                guard self.tunnelManager != nil || !self.connectors.isEmpty else { return }
                 self.connectionStatus = .reconnecting
-                IslandLogger.store.info("System woke — reconnecting")
                 // Restart tunnel
                 await self.tunnelManager?.handleSleepWake()
                 // Immediate poll to sync state
@@ -336,7 +382,9 @@ extension TaskStore {
         connection: ConnectionStatus = .connected,
         apiKey: APIKeyStatus = .valid
     ) -> TaskStore {
-        let store = TaskStore()
+        // bootstrap: false — previews and unit tests must never bind the
+        // hook server port or touch SQLite/Keychain.
+        let store = TaskStore(bootstrap: false)
         store.tasks = tasks
         store.connectionStatus = connection
         store.apiKeyStatus = apiKey
@@ -357,18 +405,20 @@ extension TaskStore {
 
     /// Replace the entire task list. Triggers an Observation update so
     /// every view bound to `tasks` re-renders (bar count, panel list).
+    /// Routed through the transition funnel so `onTaskTransition` fires —
+    /// the Debug Sandbox is how B tests notifications (contract v1.4.0).
     public func debugSetTasks(_ tasks: [AgentTask]) {
-        self.tasks = tasks
+        setTasks(tasks)
     }
 
     /// Append a single task. Used by the "+ Running / + Waiting / …" row.
     public func debugAppend(_ task: AgentTask) {
-        self.tasks.append(task)
+        setTasks(tasks + [task])
     }
 
     /// Drop every task — also exercises the empty-state rendering path.
     public func debugClearTasks() {
-        self.tasks.removeAll()
+        setTasks([])
     }
 
     /// Override the connection-status indicator (header dot + any future

--- a/IslandCoreTests/Sources/IslandCoreTests/CursorConnectorTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/CursorConnectorTests.swift
@@ -140,6 +140,16 @@ final class CursorConnectorTests: XCTestCase {
         XCTAssertEqual(tasks[0].status, .completed)
     }
 
+    func testLatePromptAfterItsOwnStopDoesNotResurrect() async {
+        // Follow-up to the outracing case: when the delayed prompt of an
+        // already-stopped generation finally lands, it must not flip the
+        // task back to .running (the generation is finished).
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.stop, generation: "g1", status: "completed"))
+        let tasks = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))
+        XCTAssertEqual(tasks[0].status, .completed, "a finished generation must stay finished")
+    }
+
     func testStopWithoutGenerationAlwaysApplies() async {
         let connector = CursorConnector()
         _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))

--- a/IslandCoreTests/Sources/IslandCoreTests/CursorConnectorTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/CursorConnectorTests.swift
@@ -49,12 +49,14 @@ final class CursorConnectorTests: XCTestCase {
     private func event(
         _ kind: CursorEvent.Kind,
         id: String = "conv-1",
+        generation: String? = nil,
         roots: [String]? = ["/Users/dev/Proj"],
         status: String? = nil
     ) -> CursorEvent {
         CursorEvent(
             hookEventName: kind,
             conversationId: id,
+            generationId: generation,
             workspaceRoots: roots,
             status: status
         )
@@ -109,6 +111,52 @@ final class CursorConnectorTests: XCTestCase {
         let connector = CursorConnector()
         let tasks = await connector.apply(event(.sessionStart, roots: nil))
         XCTAssertEqual(tasks[0].title, "Cursor session")
+    }
+
+    // MARK: - Generation guard (async hook dispatch races)
+
+    func testStaleStopFromSupersededGenerationIsDropped() async {
+        // abort g1 → user resubmits (g2) → g1's stop arrives late.
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g2"))
+        let tasks = await connector.apply(event(.stop, generation: "g1", status: "aborted"))
+        XCTAssertEqual(tasks[0].status, .running, "stale aborted stop must not override the new generation")
+    }
+
+    func testStopForCurrentGenerationApplies() async {
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))
+        let tasks = await connector.apply(event(.stop, generation: "g1", status: "completed"))
+        XCTAssertEqual(tasks[0].status, .completed)
+    }
+
+    func testStopOutracingItsOwnPromptApplies() async {
+        // Generation IDs aren't ordered: a stop we've never seen a prompt
+        // for must apply (it may have outraced its own beforeSubmitPrompt).
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))
+        let tasks = await connector.apply(event(.stop, generation: "g2", status: "completed"))
+        XCTAssertEqual(tasks[0].status, .completed)
+    }
+
+    func testStopWithoutGenerationAlwaysApplies() async {
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g2"))
+        let tasks = await connector.apply(event(.stop, status: "completed"))
+        XCTAssertEqual(tasks[0].status, .completed)
+    }
+
+    func testSessionEndClearsGenerationBookkeeping() async {
+        let connector = CursorConnector()
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g1"))
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g2"))
+        _ = await connector.apply(event(.sessionEnd))
+        // Same conversation id reappears: old superseded set must be gone.
+        _ = await connector.apply(event(.beforeSubmitPrompt, generation: "g3"))
+        let tasks = await connector.apply(event(.stop, generation: "g1", status: "completed"))
+        XCTAssertEqual(tasks[0].status, .completed, "pre-sessionEnd bookkeeping must not leak")
     }
 
     func testLocalSourcesAreIndependent() async {

--- a/IslandCoreTests/Sources/IslandCoreTests/SourceAppResolverTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/SourceAppResolverTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import IslandCore
+
+final class SourceAppResolverTests: XCTestCase {
+
+    private let cursorBundle = "com.todesktop.230313mzl4w4u92"
+    private let codexBundle = "com.openai.codex"
+
+    func testCursorResolvesOnlyWhenCursorRuns() {
+        XCTAssertEqual(
+            SourceAppResolver.resolveBundleId(source: "cursor", running: [cursorBundle, "com.apple.Terminal"]),
+            cursorBundle
+        )
+        XCTAssertNil(
+            SourceAppResolver.resolveBundleId(source: "cursor", running: ["com.apple.Terminal"])
+        )
+    }
+
+    func testCodexPrefersDesktopOverTerminal() {
+        XCTAssertEqual(
+            SourceAppResolver.resolveBundleId(source: "codex", running: [codexBundle, "com.apple.Terminal"]),
+            codexBundle
+        )
+        // CLI-only user: falls through to their terminal.
+        XCTAssertEqual(
+            SourceAppResolver.resolveBundleId(source: "codex", running: ["com.apple.Terminal"]),
+            "com.apple.Terminal"
+        )
+    }
+
+    func testClaudeCodeResolvesRunningTerminal() {
+        XCTAssertEqual(
+            SourceAppResolver.resolveBundleId(source: "claude-code", running: ["com.mitchellh.ghostty"]),
+            "com.mitchellh.ghostty"
+        )
+        XCTAssertNil(
+            SourceAppResolver.resolveBundleId(source: "claude-code", running: [cursorBundle])
+        )
+    }
+
+    func testManusAndUnknownSourcesNeverResolve() {
+        // No local app to jump to — TaskStore falls back to openTaskInBrowser.
+        XCTAssertNil(SourceAppResolver.resolveBundleId(source: "manus", running: [cursorBundle, codexBundle]))
+        XCTAssertNil(SourceAppResolver.resolveBundleId(source: "debug", running: [cursorBundle]))
+    }
+}

--- a/IslandCoreTests/Sources/IslandCoreTests/TaskTransitionTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/TaskTransitionTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import Foundation
+@testable import IslandCore
+
+final class TaskTransitionTests: XCTestCase {
+
+    private func task(
+        _ id: String,
+        source: String = "cursor",
+        status: TaskStatus
+    ) -> AgentTask {
+        AgentTask(
+            id: id, source: source, title: id, status: status,
+            createdAt: .now, updatedAt: .now, taskURL: ""
+        )
+    }
+
+    // MARK: - Pure diff
+
+    func testStatusChangeFires() {
+        let transitions = TaskTransition.diff(
+            old: [task("a", status: .running)],
+            new: [task("a", status: .completed)]
+        )
+        XCTAssertEqual(transitions.count, 1)
+        XCTAssertEqual(transitions[0].oldStatus, .running)
+        XCTAssertEqual(transitions[0].newStatus, .completed)
+    }
+
+    func testNewTaskFiresWithNilOldStatus() {
+        let transitions = TaskTransition.diff(old: [], new: [task("a", status: .running)])
+        XCTAssertEqual(transitions.count, 1)
+        XCTAssertNil(transitions[0].oldStatus)
+    }
+
+    func testRemovalDoesNotFire() {
+        let transitions = TaskTransition.diff(old: [task("a", status: .running)], new: [])
+        XCTAssertTrue(transitions.isEmpty)
+    }
+
+    func testUnchangedDoesNotFire() {
+        let transitions = TaskTransition.diff(
+            old: [task("a", status: .waiting)],
+            new: [task("a", status: .waiting)]
+        )
+        XCTAssertTrue(transitions.isEmpty)
+    }
+
+    func testSameIdDifferentSourcesAreDistinct() {
+        // "s1" on codex completing must not mask "s1" on cursor appearing.
+        let transitions = TaskTransition.diff(
+            old: [task("s1", source: "codex", status: .running)],
+            new: [
+                task("s1", source: "codex", status: .completed),
+                task("s1", source: "cursor", status: .running),
+            ]
+        )
+        XCTAssertEqual(transitions.count, 2)
+        let bySource = Dictionary(grouping: transitions, by: { $0.task.source })
+        XCTAssertEqual(bySource["codex"]?[0].oldStatus, .running)
+        XCTAssertNil(bySource["cursor"]?[0].oldStatus)
+    }
+
+    func testBatchWithMultipleChanges() {
+        let transitions = TaskTransition.diff(
+            old: [task("a", status: .running), task("b", status: .running)],
+            new: [task("a", status: .failed), task("b", status: .waiting)]
+        )
+        XCTAssertEqual(transitions.count, 2)
+    }
+
+    // MARK: - TaskStore integration (contract v1.4.0 semantics)
+
+    @MainActor
+    func testStoreFiresAfterTasksUpdated() {
+        let store = TaskStore.mock(tasks: [])
+        var seen: [TaskTransition] = []
+        var tasksAtCallback: [AgentTask] = []
+        store.onTaskTransition = { transition in
+            seen.append(transition)
+            tasksAtCallback = store.tasks
+        }
+
+        store.debugSetTasks([task("a", status: .waiting)])
+
+        XCTAssertEqual(seen.count, 1)
+        XCTAssertNil(seen[0].oldStatus)
+        XCTAssertEqual(seen[0].newStatus, .waiting)
+        // Contract: callback fires after `tasks` is already updated.
+        XCTAssertEqual(tasksAtCallback.count, 1)
+    }
+
+    @MainActor
+    func testDebugMutatorsFire() {
+        let store = TaskStore.mock(tasks: [])
+        var count = 0
+        store.onTaskTransition = { _ in count += 1 }
+
+        store.debugAppend(task("a", status: .running))          // +1 (new)
+        store.debugSetTasks([task("a", status: .completed)])    // +1 (running→completed)
+        store.debugClearTasks()                                 // +0 (removals don't fire)
+        XCTAssertEqual(count, 2)
+    }
+
+    @MainActor
+    func testLocalSnapshotFiresScopedTransitions() {
+        let store = TaskStore.mock(tasks: [
+            task("m", source: "manus", status: .running),
+            task("c", source: "cursor", status: .running),
+        ])
+        var seen: [TaskTransition] = []
+        store.onTaskTransition = { seen.append($0) }
+
+        // Cursor snapshot replaces only cursor tasks; manus untouched.
+        store.applyLocalSnapshot(source: "cursor", [task("c", source: "cursor", status: .completed)])
+
+        XCTAssertEqual(seen.count, 1)
+        XCTAssertEqual(seen[0].task.source, "cursor")
+        XCTAssertEqual(seen[0].oldStatus, .running)
+        XCTAssertEqual(seen[0].newStatus, .completed)
+    }
+}

--- a/IslandCoreTests/Sources/IslandCoreTests/TaskTransitionTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/TaskTransitionTests.swift
@@ -61,6 +61,17 @@ final class TaskTransitionTests: XCTestCase {
         XCTAssertNil(bySource["cursor"]?[0].oldStatus)
     }
 
+    func testKeyingIsNotFooledByDelimiterCharacters() {
+        // (source "a", id "b#c") must not collide with (source "a#b", id "c").
+        let transitions = TaskTransition.diff(
+            old: [task("b#c", source: "a", status: .running)],
+            new: [task("c", source: "a#b", status: .running)]
+        )
+        // The new task is genuinely new (oldStatus nil), not "unchanged".
+        XCTAssertEqual(transitions.count, 1)
+        XCTAssertNil(transitions[0].oldStatus)
+    }
+
     func testBatchWithMultipleChanges() {
         let transitions = TaskTransition.diff(
             old: [task("a", status: .running), task("b", status: .running)],

--- a/docs/INTERFACE_CONTRACT.md
+++ b/docs/INTERFACE_CONTRACT.md
@@ -1,6 +1,6 @@
 # IslandCore Interface Contract
 
-> 最后更新: 2026-04-24 | 版本: v1.0.0
+> 最后更新: 2026-07-29 | 版本: v1.4.0
 > 变更流程: 改 TaskStore 公开 API 前更新此文档,commit 用 `[S][contract]` tag。
 
 ---
@@ -30,10 +30,42 @@ public final class TaskStore {
     /// 在浏览器中打开指定任务。
     public func openTaskInBrowser(id: String)
 
+    /// 跳回任务所在的会话(v1.4.0 新增,J2 交付)。
+    /// 能解析出来源 app 时做 app 级激活(cursor → Cursor.app);
+    /// 解析不出或激活失败时回退到 openTaskInBrowser 的行为
+    /// (本地任务 → Finder 打开项目目录,Manus → 浏览器)。
+    public func jumpToTask(id: String)
+
     /// 通过 Manus API 停止任务。
     public func stopTask(id: String) async throws
+
+    // MARK: - Events (v1.4.0 新增,J1 交付)
+
+    /// 任务状态跃迁回调。B 侧(通知投递)在 app 启动时赋值一次。
+    /// - 主线程(MainActor)回调,`tasks` 已更新完毕后触发
+    /// - 每个状态发生变化的任务触发一次;新出现的任务也触发
+    ///   (oldStatus == nil);任务移除不触发
+    /// - 同一批快照里多个任务变化 → 逐个回调,顺序不保证
+    /// - Debug Sandbox 的 debug 系列 mutator 同样触发,便于 B 测通知
+    public var onTaskTransition: ((TaskTransition) -> Void)?
+}
+
+/// 一次任务状态跃迁(v1.4.0 新增)。
+public struct TaskTransition: Sendable {
+    public let task: AgentTask          // 跃迁之后的任务状态
+    public let oldStatus: TaskStatus?   // nil = 该任务首次出现
+    public let newStatus: TaskStatus    // 与 task.status 相同,便于 switch
 }
 ```
+
+**B 侧通知建议映射**(契约不强制,B 自行决定打扰度):
+
+| 跃迁 | 建议动作 |
+|---|---|
+| 任意 → `.waiting` | 通知「需要你的审批/输入」+ `waitingMessage` |
+| 任意 → `.failed` | 通知「任务失败」 |
+| `.running` → `.completed` | 通知「任务完成」(可选,默认开) |
+| 首次出现(oldStatus == nil) | 不通知(避免 app 启动时快照轰炸) |
 
 ---
 
@@ -138,3 +170,4 @@ public enum CursorHooksInstaller {  // 写 ~/.cursor/hooks.json(扁平 entry + �
 | 2026-07-28 | v1.1.0 | Claude Code 本地连接器(TaskStore API 不变) | `[S] feat(claude-code): local hooks connector` |
 | 2026-07-28 | v1.2.0 | Codex 本地连接器:`CodexHooksInstaller`(API 形态同 `ClaudeHooksInstaller`,写 `~/.codex/hooks.json`),tasks 新增 `source == "codex"`,其余约定同 claude-code | `[S] feat(codex): local hooks connector` |
 | 2026-07-29 | v1.3.0 | Cursor 本地连接器:`CursorHooksInstaller`(写 `~/.cursor/hooks.json`,扁平 entry + 顶层 `version: 1`),tasks 新增 `source == "cursor"`;仅订阅 fire-and-forget 事件(sessionStart / beforeSubmitPrompt / stop / sessionEnd),无 waiting 态;`stop.status == "error"` 映射为 failed | `[S] feat(cursor): local hooks connector` |
+| 2026-07-29 | v1.4.0 | **契约冻结(J1/J2)**:新增 `TaskTransition` 结构与 `TaskStore.onTaskTransition` 回调(状态跃迁事件,通知投递用);新增 `TaskStore.jumpToTask(id:)`(app 级激活,失败回退 openTaskInBrowser 行为)。`openTaskInBrowser` 保持不变 | `[S][contract] feat: task transitions + jump-to-task` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,286 @@
+# Dev Island 开发计划
+
+> **产品定位(终局):Every Agent — one notch, one glance。**
+> 目标覆盖 26+ 个 agent:Claude Code、Codex、ZCode、Gemini CLI、Antigravity CLI、Cursor、Trae、OpenCode、MiMoCode、Droid、Qoder、Qwen、Grok Build、Kimi Code、DeepSeek、Mistral Vibe、Copilot、CodeBuddy、WorkBuddy、Kiro、Hermes、Amp、Pi Agent、Oh My Pi、Gajae Code…
+>
+> **当前方向:先把产品做到足够好用、功能足够全面,变现后置。**
+> **当前状态:v0.2.0 已发布** —— Manus + Claude Code + Codex + Cursor 四个连接器,签名 + 公证的发布流水线。
+
+---
+
+## 一、里程碑总览
+
+| 里程碑 | 内容 | 出口条件(全部满足才算达成) | 对应发版 |
+|---|---|---|---|
+| **M0 地基** | v0.2.0 真机验收 | 验收清单 A 全绿,发现的 bug 已修复或立项 | — |
+| **M1 价值闭环** | 通知 + 跳回会话 + onboarding | "不盯终端"承诺兑现:审批弹通知、点通知/任务卡直达会话;新用户 3 分钟内跑通第一个会话 | v0.3.0 |
+| **M2 框架就绪** | 声明式连接器框架 + Wave 1 | 现有 3 连接器迁移为表驱动且回归全绿;Gemini 家族接入并通过 B 验收;设置页新列表上线 | v0.4.0 |
+| **M3 矩阵铺开** | Wave 2 + Wave 3 + 分发 | 矩阵表内 ✅ ≥ 12 家;自动更新可用;Homebrew tap 可安装;48h 挂机稳定 | v0.5.0 |
+| **M4 公开发布** | 落地页 + PH/HN 发布 | 官网上线、演示视频完成、发布日执行完毕、48h 值班响应 | v1.0.0-beta |
+| **M5 变现**(后置) | license + 支付 | 触发条件:日活稳定 + M1 体验被用户反馈验证 | v1.0.0 |
+
+---
+
+## 二、双轨并行原则与汇合点
+
+两人**始终各自有事做、互不阻塞**,靠三条规则实现:
+
+1. **契约先行**:A 的每个核心功能先出"契约 PR"(只改 `INTERFACE_CONTRACT.md`,冻结 API 形态),B 评审通过即可按契约并行开发 UI,不等 A 的实现落地。
+2. **B 永不空转**:等待 A 接口期间,B 手上永远有独立任务(onboarding、视觉、Homebrew、官网)。
+3. **汇合点即集成测试**:每个汇合点当天,两边分支都合入 main,当场跑真机联调;发现的问题谁的域谁修,24h 内闭环。
+
+| 汇合点 | 触发时机 | A 交付 | B 交付 | 联调内容 |
+|---|---|---|---|---|
+| **J1** | 阶段 1 中段 | TaskStore 状态跃迁回调(契约冻结→实现合入) | 通知投递 + 点击唤起面板 | 真实会话触发通知全链路 |
+| **J2** | 阶段 1 末 | 跳回会话 API(app 级激活) | 任务卡点击行为接入 | 三个 agent 各跑一次"黄灯→跳回→批准" |
+| **J3** | 阶段 2 初 | 声明式框架 API 冻结 | 设置页新列表(分组+搜索)对接 | 现有 4 家在新列表下开关/状态全部正常 |
+| **J4** | 每个 Wave 结束 | 该 Wave 连接器合入 | 该 Wave 真机验收 + logo | 验收清单 A 的连接器部分逐家过,B 签字 |
+| **J5** | 阶段 3 初 | v0.5.0 发版产物 | 落地页 + 支持矩阵页 | 官网下载链接→安装→跑通全流程走查 |
+
+---
+
+## 三、阶段计划(双轨)
+
+### 阶段 0:地基验收(两人一起,≈2 天)
+
+唯一任务:对照「五、验收清单 A」在两台真机上把 v0.2.0 过一遍。发现的问题按域立 issue,阻塞项当场修。
+**出口 = M0。**
+
+### 阶段 1:好用 —— 价值闭环
+
+> 主题:用户装上之后,"不用盯终端"这个承诺真正兑现。
+
+| A(核心)轨 | B(产品)轨 |
+|---|---|
+| ① 通知回调契约 PR(J1 前置) | ① onboarding 三步引导(独立,先行) |
+| ② TaskStore 状态跃迁回调实现:→completed / →waiting / →failed | ② 系统通知投递 + 设置页开关(按契约并行) |
+| ③ 跳回会话调研与实现:任务记录来源 app,NSWorkspace app 级激活(J2 前置) | ③ 通知点击 → 展开面板并高亮任务 |
+| ④ LocalHookServer 端口占用降级与提示 | ④ 胶囊信息密度:多会话计数(如 `2▶ 1⏸`) |
+| ⑤ 休眠唤醒后本地管线健康检查 | ⑤ 任务卡点击行为接入跳回 API(J2 后) |
+
+**汇合点:J1(通知链路)、J2(跳回链路)。出口 = M1,发 v0.3.0。**
+
+### 阶段 2:全面 —— 连接器矩阵铺开
+
+> 主题:"我用的 agent 它都支持",以及长期挂机不出幺蛾子。铺开策略与状态见「四、连接器矩阵」。
+
+| A(核心)轨 | B(产品)轨 |
+|---|---|
+| ① 声明式框架:现有 3 连接器迁移为表驱动,API 契约冻结(J3 前置) | ① 设置页连接器列表改版:分组 + 搜索 + 状态徽标(J3 对接) |
+| ② Wave 1:Gemini CLI + 衍生系(Qwen Code 等) | ② Wave 1 真机验收 + logo(J4) |
+| ③ Wave 2:Claude 衍生系与国产 CLI(Kimi Code、DeepSeek、CodeBuddy、Qoder、ZCode、MiMoCode…) | ③ Wave 2 真机验收 + logo(J4) |
+| ④ Wave 3:独立机制调研与接入(OpenCode、Copilot、Amp、Kiro、Trae…) | ④ Wave 3 真机验收 + logo(J4) |
+| ⑤ ChatGPT / Codex 云任务 API 调研 | ⑤ Sparkle 自动更新接入(独立) |
+| ⑥ 长期挂机稳健性:并发压测、TTL 复核、48h 内存观察 | ⑥ Homebrew tap 发布(独立) |
+| ⑦ 卸载时 hooks 一键全清 | ⑦ 会话历史视图(SQLite 已有落库基础) |
+
+**汇合点:J3(框架×列表)、J4(每 Wave 一次)。出口 = M3,发 v0.4.0 / v0.5.0。**
+
+### 阶段 3:公开发布
+
+| A(核心)轨 | B(产品)轨 |
+|---|---|
+| ① v0.5.0 → v1.0.0-beta 发版与流水线保障 | ① devisland.app 落地页(hero:15 秒状态流转录屏) |
+| ② 发布日 issue 值班(技术侧) | ② 演示视频(60-90 秒)+ 支持矩阵页 |
+| ③ 用户反馈的核心侧修复 | ③ Product Hunt / HN / X 发布执行 |
+
+**汇合点:J5。出口 = M4。**
+
+### 后置:变现(M5,时机成熟再启动)
+
+方案已调研完毕,直接取用:Lemon Squeezy(MoR 处理全球税务)+ Ed25519 离线校验 + Keychain 存储 + 14 天试用降级(保留 1 个连接器,不锁死)。
+A:LicenseManager + webhook 签发;B:激活 UI + 购买跳转 + 定价文案。
+
+---
+
+## 四、双人甘特图
+
+> 单位为工作日(D1、D2…),只表达**相对排期、并行关系与汇合点**,不承诺日历日期。GitHub 上自动渲染。
+
+```mermaid
+gantt
+    title Dev Island 双轨开发甘特图(A=核心 / B=产品)
+    dateFormat  YYYY-MM-DD
+    axisFormat  D%j
+    excludes    weekends
+
+    section 阶段0 · 两人
+    v0.2.0 真机验收(M0)          :m0, 2026-01-01, 2d
+
+    section 阶段1 · A轨
+    通知回调契约PR                 :a1, after m0, 1d
+    状态跃迁回调实现               :a2, after a1, 2d
+    跳回会话调研+实现              :a3, after a2, 3d
+    端口降级+唤醒健康检查          :a4, after a3, 2d
+
+    section 阶段1 · B轨
+    onboarding 引导               :b1, after m0, 3d
+    通知投递+设置开关(按契约)    :b2, after a1, 3d
+    通知点击→面板高亮             :b3, after b2, 1d
+    胶囊多会话计数                 :b4, after b3, 2d
+    任务卡接入跳回API              :b5, after a3, 1d
+
+    section 汇合点
+    J1 通知链路联调                :milestone, j1, after a2, 0d
+    J2 跳回链路联调·发v0.3.0(M1) :milestone, j2, after a3 b5, 0d
+
+    section 阶段2 · A轨
+    声明式框架+迁移3连接器         :a5, after j2, 3d
+    Wave1 Gemini家族               :a6, after a5, 3d
+    Wave2 Claude衍生+国产CLI       :a7, after a6, 5d
+    Wave3 独立机制调研+接入        :a8, after a7, 5d
+    云任务调研+48h稳健性           :a9, after a8, 3d
+
+    section 阶段2 · B轨
+    设置页列表改版                 :b6, after j2, 3d
+    Wave1 验收+logo                :b7, after a6, 2d
+    Sparkle 自动更新               :b8, after b7, 3d
+    Wave2 验收+logo                :b9, after a7, 2d
+    Homebrew tap + 会话历史        :b10, after b9, 3d
+    Wave3 验收+logo                :b11, after a8, 2d
+
+    section 汇合点
+    J3 框架×列表联调·发v0.4.0(M2):milestone, j3, after a5 b6, 0d
+    J4 矩阵验收完成·发v0.5.0(M3) :milestone, j4, after a9 b11, 0d
+
+    section 阶段3 · A轨
+    v1.0.0-beta 发版保障           :a10, after j4, 2d
+    发布日技术值班                 :a11, after a10, 2d
+
+    section 阶段3 · B轨
+    落地页+演示视频                :b12, after j4, 4d
+    PH/HN/X 发布执行               :b13, after b12, 1d
+
+    section 汇合点
+    J5 官网全流程走查·公开发布(M4):milestone, j5, after a11 b13, 0d
+```
+
+阅读要点:
+
+- **B 从不等 A**:J1 契约一冻结,B 的通知 UI 与 A 的回调实现同步推进;A 做框架迁移时 B 改设置页列表。
+- **验收窗口错峰**:每个 Wave,A 转入下一波开发的同时 B 验收上一波 —— 流水线式推进。
+- 甘特图是**相对排期**,实际以汇合点达成为准;某轨提前完成就从后置事项里拉任务,不空等。
+
+---
+
+## 五、分工与协作规则
+
+沿用仓库既有的 `[S]` / `[C]` 双角色模式,边界是 `docs/INTERFACE_CONTRACT.md`:
+
+| 角色 | 负责范围 | 代码域 |
+|---|---|---|
+| **A — 核心** `[S]` | 连接器框架与实现、事件管线、数据层、发布流水线 | `IslandCore/`、`IslandCoreCLI/`、`.github/workflows/` |
+| **B — 产品** `[C]` | UI/UX、通知、上手引导、连接器实测验收、分发渠道 | `IslandAppLib/`、`IslandApp/`、`dist/` |
+
+**连接器矩阵专项分工:**
+
+| 环节 | 负责人 | 说明 |
+|---|---|---|
+| 声明式连接器框架 | A | 一个 agent = 一行声明(配置路径 + 格式家族 + 事件词汇表) |
+| 每家机制调研 | A | 装真实 CLI 确认家族归属,更新「六、连接器矩阵」 |
+| 同族 agent 声明配置 | A 写,B 复核 | PR 附 CLI 端到端记录 |
+| 新机制家族攻坚 | A | 先出调研结论再排期 |
+| 每家真机实测验收 | **B** | 对照验收清单 A 逐项过,**B 签字后才算"已支持"** |
+| 设置页列表改版 / 每家 logo | B | 分组 + 搜索 + 状态徽标;品牌色块替代字母缩写 |
+| README / 官网支持矩阵 | B | 对外只宣传 ✅ 的,未验收标 beta |
+
+**协作规则:**
+
+1. A 改动任何 IslandCore 公开 API,必须**同一个 PR 内**更新 `INTERFACE_CONTRACT.md`(版本号 + 变更记录表)。
+2. B 只依赖契约文档编程,不直接读 IslandCore 实现细节做假设。
+3. 所有变更走 PR → squash 合并 main(分支保护已开启,禁止直接 push main)。
+4. 分支命名:`feat/xxx`、`fix/xxx`、`chore/xxx`;提交信息带 `[S]` / `[C]` 前缀标注责任域。
+5. 每个汇合点做一次面对面联调;此外每周 30 分钟同步,更新本文档勾选状态。
+6. 跨域改动由 A 先出核心 PR,合并后 B 基于 main 出 UI PR,**不搞叠 PR**(v0.2.0 期间叠 PR 被 GitHub 自动关闭过一次,教训)。
+
+---
+
+## 六、连接器矩阵(调研 + 状态总表)
+
+> 状态流转:📋 待调研 → 🔬 调研中 → 🛠 开发中 → 🧪 待 B 验收 → ✅ 已支持 / ❌ 暂不可行(记录原因)
+> "家族"指集成机制:`claude-hooks`(~/.xxx/settings.json 嵌套格式)、`gemini-hooks`、`cursor-hooks`(扁平 + version)、`api`(云端轮询/webhook)、`custom`(插件/其他)。
+
+| Agent | 家族(预判) | 状态 | 负责 | 备注 |
+|---|---|---|---|---|
+| Claude Code | claude-hooks | ✅ | — | v0.2.0 |
+| Codex | claude-hooks | ✅ | — | v0.2.0,写 ~/.codex/hooks.json |
+| Cursor | cursor-hooks | ✅ | — | v0.2.0,含 stop.status→failed |
+| Manus | api | ✅ | — | v0.1.x,轮询 + webhook |
+| Gemini CLI | gemini-hooks | 📋 | A | Wave 1 头号目标 |
+| Qwen(Qwen Code) | gemini-hooks? | 📋 | A | Gemini CLI 衍生,大概率同族 |
+| Kimi Code | claude-hooks? | 📋 | A | 待装机确认 |
+| DeepSeek | 📋 | 📋 | A | CLI 形态待确认 |
+| ZCode | 📋 | 📋 | A | |
+| MiMoCode | 📋 | 📋 | A | |
+| CodeBuddy | claude-hooks? | 📋 | A | |
+| Qoder | 📋 | 📋 | A | |
+| Trae | custom? | 📋 | A | IDE 形态,可能无 CLI hooks |
+| OpenCode | custom? | 📋 | A | 有插件/事件 API,单独调研 |
+| Copilot | custom? | 📋 | A | Copilot CLI hooks 能力待确认 |
+| Amp | 📋 | 📋 | A | |
+| Droid | 📋 | 📋 | A | |
+| Kiro | custom? | 📋 | A | IDE,自有 agent hooks 概念 |
+| Grok Build | 📋 | 📋 | A | |
+| Mistral Vibe | 📋 | 📋 | A | |
+| Antigravity CLI | 📋 | 📋 | A | |
+| Hermes | 📋 | 📋 | A | |
+| Pi Agent | 📋 | 📋 | A | |
+| Oh My Pi | 📋 | 📋 | A | |
+| WorkBuddy | 📋 | 📋 | A | |
+| Gajae Code | 📋 | 📋 | A | |
+| ChatGPT / Codex 云 | api | 📋 | A | 官方任务状态 API 待调研 |
+
+> 维护:A 每完成一家调研就更新本表;B 验收通过后把状态改成 ✅ 并注明版本。对外(README/官网)只宣传 ✅ 的。
+
+---
+
+## 七、验收清单
+
+### A. v0.2.0 真机验收(M0,阶段 1 开工前必须全过)
+
+**安装与启动:**
+- [ ] 从 Releases 下载 `Dev-Island.zip`,解压拖入 /Applications,双击启动**无任何 Gatekeeper 警告**
+- [ ] 菜单栏出现胶囊,鼠标悬停展开面板
+- [ ] `spctl -a -vv -t exec "/Applications/Dev Island.app"` 输出 accepted / Notarized Developer ID
+
+**三个本地连接器(每个都单独验证):**
+- [ ] 设置页打开开关后,对应配置文件里出现我们的 hook 条目,且**用户原有条目原样保留**(`~/.claude/settings.json` / `~/.codex/hooks.json` / `~/.cursor/hooks.json`)
+- [ ] 跑一个真实会话:开始 → 岛变蓝(running);结束 → 变绿(completed)
+- [ ] Claude Code / Codex:触发一次权限请求 → 变黄(waiting),批准后恢复
+- [ ] Cursor:agent 出错中断 → 变红(failed)
+- [ ] 关闭开关后,配置文件里我们的条目被干净移除,用户条目仍在
+- [ ] Dev Island 完全退出时,跑上述 CLI 会话**不卡顿、不报错**(fire-and-forget 验证)
+
+**共存与恢复:**
+- [ ] Manus(有 key 的话)与本地连接器同时显示,互不覆盖
+- [ ] 断网状态下本地连接器照常工作
+- [ ] 合盖休眠 10 分钟后唤醒,新会话事件仍能进岛
+- [ ] 手动占用 7824 端口再启动 app,确认行为(已知薄弱点,阶段 1 修复)
+
+### B. 每个 PR 合并前(双方自查)
+
+- [ ] `swift build && swift test` 本地全绿
+- [ ] 改了 IslandCore 公开 API → `INTERFACE_CONTRACT.md` 同 PR 更新
+- [ ] 新连接器 / 新功能 → 有单测;涉及 hook → CLI (`swift run IslandCoreCLI local-hooks`) 端到端跑过
+- [ ] README 的状态表若受影响则同步更新
+- [ ] PR 描述含 Test plan(照抄 #3/#5/#6 的格式)
+
+### C. 每次发版(tag 前)
+
+- [ ] `VERSION` 文件与 tag 一致(流水线会强制校验,不一致直接 fail)
+- [ ] main 上 `swift test` 全绿
+- [ ] `scripts/build-app.sh` 本地跑通,产物能启动
+- [ ] tag 推送后盯流水线到 Release 产物出现(公证偶发排队 20+ 分钟属正常;403 协议错误 → developer.apple.com 重签协议)
+- [ ] 从 Releases 下载产物做一次冒烟:安装、启动、开一个连接器
+- [ ] Homebrew cask 的 sha256 同步更新(tap 发布后)
+
+### D. 每个汇合点(J1-J5,联调当天)
+
+- [ ] 两轨分支均已合入 main,CI 全绿
+- [ ] 真机联调按该汇合点的「联调内容」执行并记录结果
+- [ ] 发现的问题按域立 issue,24h 内闭环或明确降级方案
+- [ ] 若为发版汇合点(J2/J3/J4),执行清单 C
+
+---
+
+*维护约定:本文档随每个汇合点与每周同步更新;阶段与排期调整走 PR 讨论。*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,7 +74,7 @@
 | ⑥ 长期挂机稳健性:并发压测、TTL 复核、48h 内存观察 | ⑥ Homebrew tap 发布(独立) |
 | ⑦ 卸载时 hooks 一键全清 | ⑦ 会话历史视图(SQLite 已有落库基础) |
 
-**汇合点:J3(框架×列表)、J4(每 Wave 一次)。出口 = M3,发 v0.4.0 / v0.5.0。**
+**汇合点:J3(框架×列表,达成即发 v0.4.0 = M2)、J4(每 Wave 一次,全部 Wave 验收完发 v0.5.0 = M3)。出口 = M3。**
 
 ### 阶段 3:公开发布
 
@@ -95,13 +95,13 @@ A:LicenseManager + webhook 签发;B:激活 UI + 购买跳转 + 定价文案。
 
 ## 四、双人甘特图
 
-> 单位为工作日(D1、D2…),只表达**相对排期、并行关系与汇合点**,不承诺日历日期。GitHub 上自动渲染。
+> 起始日期为占位符,只表达**相对排期、并行关系与汇合点**,不承诺日历日期。GitHub 上自动渲染。
 
 ```mermaid
 gantt
     title Dev Island 双轨开发甘特图(A=核心 / B=产品)
     dateFormat  YYYY-MM-DD
-    axisFormat  D%j
+    axisFormat  %m-%d
     excludes    weekends
 
     section 阶段0 · 两人


### PR DESCRIPTION
## Summary

A 轨阶段 1 交付,覆盖 J1、J2 两个汇合点的核心侧全部内容。契约 v1.4.0 已在首个 commit 冻结,B 可直接对接。

### J1 — 任务状态跃迁回调(通知投递的地基)
- 新增 `TaskTransition` + `TaskStore.onTaskTransition`(主线程回调,`tasks` 更新完毕后触发;新任务 `oldStatus == nil`;移除不触发)
- 所有 `tasks` 写入收敛到单一 `setTasks` 漏斗,按 `(source, id)` diff——同名会话 id 跨源不串
- Debug Sandbox 的 debug mutators 同样触发,B 可以在沙盒里直接测通知

### J2 — 跳回会话
- 新增 `TaskStore.jumpToTask(id:)`:app 级激活来源应用(cursor → Cursor.app;codex → Codex Desktop,其次运行中的终端;claude-code → 运行中的终端候选表);无可激活对象时回退 `openTaskInBrowser` 行为

### 加固(A 轨阶段 1 遗留项)
- `LocalHookServer`:端口被占不再静默死亡——有限次退避重试 + 唤醒时 `ensureRunning()` 复活
- 睡眠/唤醒观察者不再依赖 Manus key 才注册(此前本地-only 用户完全没有唤醒健康检查)
- Cursor generation 守卫:被新 prompt 取代的 generation 的迟到 `stop` 直接丢弃,修复"中止后重发消息仍显示 Aborted"的竞态;未知 generation 一律放行(ID 无序,防误杀)
- `TaskStore.mock()` 不再 bootstrap:预览/单测不再真的绑 7824 端口、碰 SQLite/Keychain

另附 `docs/ROADMAP.md`(双人分阶段计划、J1–J5 汇合点、甘特图、连接器矩阵)。

## Test plan
- [x] `swift test` 全量 99 个用例通过(新增 28 个:transition diff 与 TaskStore 集成、SourceAppResolver 解析、generation 守卫)
- [ ] 真机:Cursor 中止后重发消息,胶囊应变蓝(此前偶发保持灰色 Aborted)
- [ ] 真机:占用 7824 端口启动 app,日志应出现 retry;释放端口 + 睡眠唤醒后管线恢复