### PR TITLE
feat(app): interaction polish — hand cursor, hover/press feedback

### DIFF
--- a/IslandAppLib/Theme/Interaction.swift
+++ b/IslandAppLib/Theme/Interaction.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import AppKit
+
+// Shared interaction affordances for elements inside the island window.
+
+/// Hover-driven pointing-hand cursor for interactive panel elements.
+///
+/// Uses `NSCursor.set()` rather than the push/pop stack: our borderless,
+/// non-key window doesn't participate in AppKit's cursor-rect machinery,
+/// so a push whose matching pop is skipped (click morphs the hierarchy
+/// before un-hover fires) permanently corrupts the stack. `set()` is
+/// idempotent and self-healing — the window's mouse-tracking poll resets
+/// the cursor at every silhouette boundary crossing anyway.
+struct PointingHandCursor: ViewModifier {
+    func body(content: Content) -> some View {
+        content.onHover { hovering in
+            if hovering {
+                NSCursor.pointingHand.set()
+            } else {
+                NSCursor.arrow.set()
+            }
+        }
+    }
+}
+
+extension View {
+    func pointingHandCursor() -> some View {
+        modifier(PointingHandCursor())
+    }
+}
+
+/// Press feedback for panel buttons: a quick, subtle scale-down while the
+/// mouse button is held. `.plain` (used before) gives zero visual response
+/// to a press, which reads as "did that register?".
+struct PressableButtonStyle: ButtonStyle {
+    /// 0.98 for card-sized surfaces; icons pass something smaller-delta.
+    var pressedScale: CGFloat = 0.98
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? pressedScale : 1)
+            .opacity(configuration.isPressed ? 0.85 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+}

--- a/IslandAppLib/Views/Island/IslandRootView.swift
+++ b/IslandAppLib/Views/Island/IslandRootView.swift
@@ -318,14 +318,13 @@ struct IslandRootView: View {
         switch mode {
         case .collapsed:
             // Hover only widens the bar (clickable affordance). The panel
-            // opens on click, not hover-dwell.
+            // opens on click, not hover-dwell. The pointing-hand cursor is
+            // owned by IslandWindow's mouse poll — NSCursor push/pop from
+            // here never worked (AppKit cursorUpdate resets non-key
+            // borderless windows to arrow) and leaked stack pushes when a
+            // click expanded the panel before the un-hover pop could fire.
             withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
                 isHovering = hovering
-            }
-            if hovering {
-                NSCursor.pointingHand.push()
-            } else {
-                NSCursor.pop()
             }
 
         case .expanded:

--- a/IslandAppLib/Views/NotchPanel/NotchPanelView.swift
+++ b/IslandAppLib/Views/NotchPanel/NotchPanelView.swift
@@ -97,7 +97,8 @@ struct NotchPanelView: View {
                     .frame(width: 22, height: 22)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(PressableButtonStyle(pressedScale: 0.9))
+            .pointingHandCursor()
         }
     }
 
@@ -189,7 +190,8 @@ struct NotchPanelView: View {
             .padding(.vertical, 11)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
+        .pointingHandCursor()
     }
 
     // MARK: - Geometry

--- a/IslandAppLib/Views/NotchPanel/TaskCard.swift
+++ b/IslandAppLib/Views/NotchPanel/TaskCard.swift
@@ -59,6 +59,9 @@ struct TaskCard: View {
             .background {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .fill(isHovering ? Palette.cardHover : Palette.cardBg)
+                    // Ease the highlight in/out — the hard cut read as
+                    // flicker when skimming the cursor down the list.
+                    .animation(.easeOut(duration: 0.12), value: isHovering)
             }
             .overlay(alignment: .bottom) {
                 if task.status == .running {
@@ -69,8 +72,9 @@ struct TaskCard: View {
                 }
             }
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableButtonStyle())
         .onHover { isHovering = $0 }
+        .pointingHandCursor()
         .onReceive(timer) { tick = $0 }
     }
 

--- a/IslandAppLib/Windows/BackgroundCursor.swift
+++ b/IslandAppLib/Windows/BackgroundCursor.swift
@@ -1,0 +1,48 @@
+import AppKit
+import os
+
+// SkyLight (WindowServer) private connection property that lets a
+// NON-ACTIVE app set the mouse cursor.
+//
+// Why we need it: Dev Island is an `.accessory` app whose island window
+// never activates. macOS only honors `NSCursor.set()` from the active
+// app — or, briefly, from any app while it is processing a mouse-down —
+// which is exactly the symptom we shipped: the pointing hand appeared
+// during clicks but never on hover. With this property set, the window
+// server accepts our cursor writes while we're in the background, and the
+// 25Hz re-assert in `IslandWindow.tickMouseTracking` becomes effective.
+//
+// Private API, but long-stable and widely shipped (Alt-Tab, Rectangle,
+// MiddleClick…). We distribute outside the App Store, so no review
+// constraint applies. Failure is graceful: if a future macOS drops the
+// property the call returns an error and the cursor simply stays an
+// arrow — the pre-fix behavior.
+private typealias CGSConnectionID = UInt32
+
+@_silgen_name("CGSMainConnectionID")
+private func CGSMainConnectionID() -> CGSConnectionID
+
+@_silgen_name("CGSSetConnectionProperty")
+private func CGSSetConnectionProperty(
+    _ cid: CGSConnectionID,
+    _ targetCID: CGSConnectionID,
+    _ key: CFString,
+    _ value: CFTypeRef
+) -> CGError
+
+enum BackgroundCursor {
+    /// Idempotent; call once at startup before any cursor writes.
+    static func enable() {
+        let connection = CGSMainConnectionID()
+        let result = CGSSetConnectionProperty(
+            connection,
+            connection,
+            "SetsCursorInBackground" as CFString,
+            kCFBooleanTrue
+        )
+        if result != .success {
+            Logger(subsystem: "app.devisland.Island", category: "window")
+                .warning("SetsCursorInBackground failed (\(result.rawValue)) — hover cursor will stay an arrow")
+        }
+    }
+}

--- a/IslandAppLib/Windows/IslandWindow.swift
+++ b/IslandAppLib/Windows/IslandWindow.swift
@@ -43,6 +43,11 @@ public final class IslandWindow: NSWindow {
 
     private var mouseTrackingTimer: Timer?
 
+    /// Whether the poll below last set the pointing-hand cursor. Cursor
+    /// writes happen only on transitions, so panel sub-elements (task
+    /// cards, buttons) remain free to set their own cursor while expanded.
+    private var cursorShowsPointingHand = false
+
     public init() {
         let initialLayout = NotchMetrics.current()
 
@@ -142,6 +147,27 @@ public final class IslandWindow: NSWindow {
         let shouldIgnore = !inside
         if ignoresMouseEvents != shouldIgnore {
             ignoresMouseEvents = shouldIgnore
+        }
+
+        // Pointing-hand affordance for the collapsed bar (the whole bar is
+        // one big "open the panel" button). Driven from this poll — the
+        // SwiftUI-side NSCursor push/pop was unreliable in this borderless,
+        // non-key window (AppKit cursorUpdate kept resetting to arrow, and
+        // the pop leg never ran after click-to-expand). Writes fire on
+        // transitions only: while expanded, panel sub-elements own the
+        // cursor via `.pointingHandCursor()`.
+        let wantsHand = inside && IslandCoordinator.shared.mode == .collapsed
+        if wantsHand {
+            // Re-assert EVERY tick, not just on the transition: as a
+            // non-active app our set() can be clobbered whenever the
+            // system or the active app touches the cursor, and there's no
+            // notification for that. set() is idempotent and cheap at
+            // 25Hz, so continuous re-assert is the reliable option.
+            NSCursor.pointingHand.set()
+            cursorShowsPointingHand = true
+        } else if cursorShowsPointingHand {
+            cursorShowsPointingHand = false
+            NSCursor.arrow.set()
         }
     }
 

--- a/IslandAppLib/Windows/IslandWindow.swift
+++ b/IslandAppLib/Windows/IslandWindow.swift
@@ -95,6 +95,10 @@ public final class IslandWindow: NSWindow {
         layout = initialLayout
         reposition()
 
+        // Must precede any cursor writes from the poll below — without it
+        // macOS discards NSCursor.set() from non-active apps entirely
+        // (the hand only flashed during clicks, never on hover).
+        BackgroundCursor.enable()
         startMouseTracking()
     }
 


### PR DESCRIPTION
## Summary

用户反馈:悬停灵动岛时鼠标不变手型。根因:旧实现用 SwiftUI onHover 里的 `NSCursor.push()/pop()`,但我们的窗口是无边框、不抢焦点的,AppKit 的 cursorUpdate 会不断把光标重置回箭头;而且点击展开面板后 pop 永远不执行,光标栈持续泄漏。

修复与打磨:
- 手型光标改由 `IslandWindow` 既有的 25Hz 鼠标轮询管理,悬停胶囊内时逐帧重设(`set()` 幂等、开销可忽略),后台 app 也抢得过系统重置
- 新增 `pointingHandCursor()` 修饰符 + `PressableButtonStyle`(按下缩放/变暗反馈),应用到任务卡、齿轮、Connect Service
- 任务卡悬停高亮从硬切改为 120ms 缓动

## Test plan
- [x] `swift build` 通过;debug 构建已在真机运行
- [ ] 人肉验证:悬停胶囊 → 手型;移出 → 箭头;展开面板后卡片/按钮 → 手型;按下卡片有缩放反馈

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the hand cursor over the collapsed island reliable on hover (even when the app isn’t active) and adds hover/press feedback to panel elements. Cursor is driven by the window’s 25Hz mouse poll; cards/buttons get a subtle press scale and eased hover highlight.

- **Bug Fixes**
  - Replaced unreliable `NSCursor.push/pop` with `NSCursor.set()` driven by the window mouse poll; re-asserts every tick while hovering the collapsed bar and resets to arrow on exit.
  - Enabled background cursor writes via SkyLight `SetsCursorInBackground` at window init so hover hand works without clicks; failure falls back to arrow with a log warning.

- **New Features**
  - Added `pointingHandCursor()` and `PressableButtonStyle` (scale + dim on press).
  - Applied to task cards, the gear button, and Connect Service; task-card hover highlight now eases in/out over 120ms.

<sup>Written for commit 820fda9702f7bd0885ab9a887571dcba8b4f7424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sheepxux/Dev-Island/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

