### PR TITLE
feat(app): notifications, welcome tour, and multi-session summary

### DIFF
--- a/IslandApp/IslandApp.swift
+++ b/IslandApp/IslandApp.swift
@@ -8,23 +8,25 @@ struct IslandApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        // Settings scene is intentionally empty for v1's PoC — the real UI
-        // lives in custom NSWindows owned by AppDelegate. Task 6 builds out
-        // the SettingsWindow.
-        Settings { EmptyView() }
+        // Keep the native Command-, entry point useful as well as the island's
+        // custom gear-button window. Both host the same settings surface.
+        Settings { SettingsView() }
     }
 }
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var islandWindow: IslandWindow?
     private var screenChangeObserver: NSObjectProtocol?
     private var openSettingsObserver: NSObjectProtocol?
+    private var openOnboardingObserver: NSObjectProtocol?
 
     /// Lazily-created so we don't pay the SwiftUI view-construction cost
     /// until the user actually opens settings. Re-used across opens —
     /// the second gear tap brings the same window forward instead of
     /// stacking a new one.
     private var settingsWindow: SettingsWindow?
+    private var onboardingWindow: OnboardingWindow?
 
     /// Conventional menu-bar icon (`NSStatusItem`): visible whenever the
     /// app — and therefore the local hook backend — is running. Menu
@@ -83,7 +85,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.islandWindow?.reposition()
+            Task { @MainActor [weak self] in
+                self?.islandWindow?.reposition()
+            }
         }
 
         // Settings window plumbing. Panel's gear button posts this
@@ -95,7 +99,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.openSettings()
+            Task { @MainActor [weak self] in
+                self?.openSettings()
+            }
+        }
+
+        openOnboardingObserver = NotificationCenter.default.addObserver(
+            forName: .islandOpenOnboardingRequested,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.openOnboarding()
+            }
         }
 
         // Banner notifications for task state transitions
@@ -120,10 +136,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // the panel is empty until at least one agent is connected, and
         // Settings is where connectors get set up.
         let defaults = UserDefaults.standard
-        if !defaults.bool(forKey: "island.didCompleteFirstLaunch") {
-            defaults.set(true, forKey: "island.didCompleteFirstLaunch")
+        if !defaults.bool(forKey: OnboardingWindow.completionKey) {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-                self?.openSettings()
+                self?.openOnboarding()
             }
         }
     }
@@ -133,6 +148,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NotificationCenter.default.removeObserver(observer)
         }
         if let observer = openSettingsObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = openOnboardingObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         removePanelEventMonitors()
@@ -147,6 +165,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         let window = SettingsWindow()
         settingsWindow = window
+        window.bringToFront()
+    }
+
+    private func openOnboarding() {
+        if let existing = onboardingWindow {
+            existing.bringToFront()
+            return
+        }
+
+        let window = OnboardingWindow { [weak self] in
+            UserDefaults.standard.set(true, forKey: OnboardingWindow.completionKey)
+            self?.onboardingWindow?.close()
+            self?.onboardingWindow = nil
+            IslandCoordinator.shared.expand()
+        }
+        onboardingWindow = window
         window.bringToFront()
     }
 

--- a/IslandAppLib/Coordinator/IslandCoordinator.swift
+++ b/IslandAppLib/Coordinator/IslandCoordinator.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import IslandCore
 import Observation
 import SwiftUI
 
@@ -26,6 +27,11 @@ public final class IslandCoordinator {
     }
 
     public private(set) var mode: Mode = .collapsed
+
+    /// Task the expanded panel should reveal and visually emphasize. This is
+    /// set by notification clicks, then cleared when the user leaves the
+    /// panel or opens the task.
+    public private(set) var highlightedTask: TaskIdentity?
 
     /// Called on the main thread whenever `mode` actually changes. Kept for
     /// AppKit-side window plumbing (e.g. installing event monitors). SwiftUI
@@ -64,9 +70,22 @@ public final class IslandCoordinator {
         setMode(.expanded)
     }
 
+    /// Open the panel on a specific task. Reassigning while already expanded
+    /// is intentional: it lets two notification clicks retarget the panel.
+    public func expand(highlighting task: TaskIdentity) {
+        cancelAllTimers()
+        highlightedTask = task
+        setMode(.expanded)
+    }
+
     public func collapse() {
         cancelAllTimers()
+        highlightedTask = nil
         setMode(.collapsed)
+    }
+
+    public func clearHighlight() {
+        highlightedTask = nil
     }
 
     public func toggle() {

--- a/IslandAppLib/Notifications/TaskNotifier.swift
+++ b/IslandAppLib/Notifications/TaskNotifier.swift
@@ -1,193 +1,228 @@
 import AppKit
 import IslandCore
-import Observation
 import OSLog
 import UserNotifications
 
-/// Posts macOS banner notifications when `TaskStore.shared.tasks`
-/// transitions through specific status changes (CLAUDE_CLIENT.md §6
-/// task 5):
-///
-/// - `running → completed` → "Task Completed" banner
-/// - any state `→ waiting` → "Task Needs Input" banner
-///
-/// Tap a banner to open the task's URL in the default browser via
-/// `NSWorkspace.shared.open`. The URL is stashed in
-/// `UNNotificationContent.userInfo["taskURL"]` and recovered in the
-/// `UNUserNotificationCenterDelegate` callback.
-///
-/// Observation: TaskStore is `@Observable` (Swift 5.9 macro). We use
-/// `withObservationTracking` and re-arm after each fire — the
-/// non-SwiftUI canonical pattern. First observation pass establishes
-/// a baseline so existing tasks at launch don't spam notifications.
+private let taskNotifierLog = Logger(
+    subsystem: "app.devisland.Island",
+    category: "notifier"
+)
+private let taskNotificationSourceKey = "taskSource"
+private let taskNotificationIDKey = "taskID"
+
+public extension Notification.Name {
+    static let islandNotificationAuthorizationChanged = Notification.Name(
+        "island.notificationAuthorizationChanged"
+    )
+}
+
+/// User-facing notification switches. Attention-required events default on;
+/// completion banners default off so Dev Island stays quiet unless a task is
+/// blocked or failed.
+public enum TaskNotificationPreferences {
+    public static let attentionRequiredKey = "island.notifications.attentionRequired"
+    public static let completionsKey = "island.notifications.completions"
+
+    public static func registerDefaults(in defaults: UserDefaults = .standard) {
+        defaults.register(defaults: [
+            attentionRequiredKey: true,
+            completionsKey: false,
+        ])
+    }
+}
+
+/// Pure transition policy, separated from UserNotifications so the product's
+/// "notify only when useful" rules are easy to unit test.
+enum TaskNotificationKind: Equatable {
+    case waiting
+    case failed
+    case completed
+
+    static func decide(
+        for transition: TaskTransition,
+        attentionRequired: Bool,
+        completions: Bool
+    ) -> Self? {
+        // A newly discovered task is usually a bootstrap snapshot, not a
+        // live transition. Never turn startup state into a banner storm.
+        guard let oldStatus = transition.oldStatus else { return nil }
+
+        switch transition.newStatus {
+        case .waiting where attentionRequired:
+            return .waiting
+        case .failed where attentionRequired:
+            return .failed
+        case .completed where completions && oldStatus != .completed:
+            return .completed
+        default:
+            return nil
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .waiting:   return "Task Needs Input"
+        case .failed:    return "Task Failed"
+        case .completed: return "Task Completed"
+        }
+    }
+
+    var identifierComponent: String {
+        switch self {
+        case .waiting:   return "waiting"
+        case .failed:    return "failed"
+        case .completed: return "completed"
+        }
+    }
+}
+
+/// Turns `TaskStore.onTaskTransition` events into macOS notifications and
+/// routes notification clicks back into the in-app task list.
 @MainActor
 public final class TaskNotifier: NSObject, UNUserNotificationCenterDelegate {
     public static let shared = TaskNotifier()
 
-    private static let log = Logger(subsystem: "app.devisland.Island", category: "notifier")
+    private var started = false
+    public private(set) var authorizationIssue: String?
 
-    /// Last seen task list, keyed by ID. We diff this against each new
-    /// snapshot to find status transitions.
-    private var previousTasksById: [String: AgentTask] = [:]
+    private override init() {
+        super.init()
+    }
 
-    /// First observation pass loads `previousTasksById` without firing
-    /// any notifications — otherwise every existing task would trigger
-    /// on launch (`running` already running, `waiting` already waiting,
-    /// etc).
-    private var hasBaseline = false
-
-    private override init() { super.init() }
-
-    /// True when the host bundle is a real `.app` (i.e., the kind of
-    /// thing `xcodebuild` / `Xcode` Run produces). False when launched
-    /// directly from SPM's `.build/debug/IslandApp` — that path has no
-    /// `Info.plist` / bundle identifier, and `UNUserNotificationCenter.current()`
-    /// throws an NSInternalInconsistencyException ("bundleProxyForCurrentProcess
-    /// is nil") on first access. We use this as a graceful-degradation
-    /// gate so dev builds via `swift run` don't crash on launch — they
-    /// just silently skip banner posting. Real .app builds (and the
-    /// eventual Homebrew Cask / Xcode-built artifact) get full
-    /// notification support.
+    /// Bare `swift run` executables have no app bundle identity and crash on
+    /// first access to `UNUserNotificationCenter.current()`. Packaged `.app`
+    /// builds have full support.
     public static var hasNotificationSupport: Bool {
         Bundle.main.bundleURL.pathExtension == "app"
     }
 
-    /// Become the system notification delegate, request authorization,
-    /// and start observing `TaskStore.shared.tasks` for transitions.
-    /// Idempotent — safe to call once at app launch.
+    /// Attach once to the transition callback and request permission when at
+    /// least one class of notification is enabled.
     public func start() {
+        guard !started else { return }
+        started = true
+
+        TaskNotificationPreferences.registerDefaults()
+        TaskStore.shared.onTaskTransition = { [weak self] transition in
+            self?.handle(transition)
+        }
+
         guard Self.hasNotificationSupport else {
-            Self.log.info("Skipping UN setup — host is not a .app bundle (\(Bundle.main.bundleURL.path)). Run via Xcode/built .app to test banner notifications.")
-            // Still observe so the diff machinery runs and we'd catch any
-            // transition-detection bugs in dev. Just don't post banners.
-            observeTaskStore()
+            taskNotifierLog.info("Skipping notification setup because the host is not an app bundle")
             return
         }
 
         UNUserNotificationCenter.current().delegate = self
+        refreshAuthorizationIfNeeded()
+    }
+
+    /// Called when Settings enables a notification category after launch.
+    public func refreshAuthorizationIfNeeded() {
+        guard Self.hasNotificationSupport else { return }
+        let defaults = UserDefaults.standard
+        let isEnabled = defaults.bool(forKey: TaskNotificationPreferences.attentionRequiredKey)
+            || defaults.bool(forKey: TaskNotificationPreferences.completionsKey)
+        guard isEnabled else { return }
 
         Task {
             do {
                 let granted = try await UNUserNotificationCenter.current()
                     .requestAuthorization(options: [.alert, .sound])
-                Self.log.info("Notification authorization granted=\(granted)")
+                taskNotifierLog.info("Notification authorization granted=\(granted)")
+                publishAuthorizationIssue(
+                    granted ? nil : "Notifications are disabled in System Settings."
+                )
             } catch {
-                Self.log.error("Notification auth failed: \(String(describing: error))")
+                let nsError = error as NSError
+                taskNotifierLog.error("Notification authorization failed: domain=\(nsError.domain, privacy: .public) code=\(nsError.code) description=\(nsError.localizedDescription, privacy: .public)")
+                publishAuthorizationIssue(nsError.localizedDescription)
             }
-        }
-
-        observeTaskStore()
-    }
-
-    // MARK: - Observation
-
-    /// Re-arming `withObservationTracking` loop. The closure body reads
-    /// every property we want to track for changes; `onChange` fires
-    /// ONCE when any of them changes, after which we have to re-register.
-    private func observeTaskStore() {
-        withObservationTracking {
-            _ = TaskStore.shared.tasks
-        } onChange: {
-            // onChange runs synchronously off the observed property's
-            // setter — hop back to MainActor before touching anything
-            // and re-arm observation.
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.handleUpdate(TaskStore.shared.tasks)
-                self.observeTaskStore()
-            }
-        }
-
-        // Establish baseline on first call, no notifications.
-        if !hasBaseline {
-            handleUpdate(TaskStore.shared.tasks)
         }
     }
 
-    private func handleUpdate(_ newTasks: [AgentTask]) {
-        let newById = Dictionary(uniqueKeysWithValues: newTasks.map { ($0.id, $0) })
-
-        if !hasBaseline {
-            previousTasksById = newById
-            hasBaseline = true
-            Self.log.debug("Baseline set with \(newById.count) tasks")
-            return
-        }
-
-        for (id, newTask) in newById {
-            guard let oldTask = previousTasksById[id] else {
-                // Brand-new task this update — no transition to fire on.
-                // (If it arrived already in `.waiting`, we deliberately
-                // skip it to avoid spamming on initial bootstrap of a
-                // fresh API key configuration.)
-                continue
-            }
-            guard oldTask.status != newTask.status else { continue }
-
-            switch (oldTask.status, newTask.status) {
-            case (.running, .completed):
-                postCompletedNotification(task: newTask)
-            case (_, .waiting):
-                postWaitingNotification(task: newTask)
-            default:
+    /// Refresh the Settings warning after the user returns from System
+    /// Settings. A request-time error is retained while status is still
+    /// undetermined so local ad-hoc builds remain diagnosable.
+    public func refreshAuthorizationState() {
+        guard Self.hasNotificationSupport else { return }
+        Task {
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                publishAuthorizationIssue(nil)
+            case .denied:
+                publishAuthorizationIssue("Notifications are disabled in System Settings.")
+            case .notDetermined:
+                break
+            @unknown default:
                 break
             }
         }
-
-        previousTasksById = newById
     }
 
-    // MARK: - Posting
+    private func publishAuthorizationIssue(_ issue: String?) {
+        authorizationIssue = issue
+        NotificationCenter.default.post(
+            name: .islandNotificationAuthorizationChanged,
+            object: self
+        )
+    }
 
-    private func postCompletedNotification(task: AgentTask) {
+    private func handle(_ transition: TaskTransition) {
+        let defaults = UserDefaults.standard
+        guard let kind = TaskNotificationKind.decide(
+            for: transition,
+            attentionRequired: defaults.bool(forKey: TaskNotificationPreferences.attentionRequiredKey),
+            completions: defaults.bool(forKey: TaskNotificationPreferences.completionsKey)
+        ) else { return }
+
+        post(kind, for: transition.task)
+    }
+
+    private func post(_ kind: TaskNotificationKind, for task: AgentTask) {
         guard Self.hasNotificationSupport else {
-            Self.log.debug("(skip) running→completed for \(task.id) — no .app bundle")
+            taskNotifierLog.debug("Skipping \(kind.identifierComponent) notification for \(task.source)/\(task.id)")
             return
         }
-        let content = UNMutableNotificationContent()
-        content.title = "Task Completed"
-        content.body = task.title
-        content.userInfo = ["taskURL": task.taskURL]
-        content.sound = .default
 
-        // Per-task identifier so a re-fire (e.g. status flapping under
-        // a flaky network) replaces the previous banner instead of
-        // stacking duplicates.
-        let id = "task-completed-\(task.id)"
-        let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
+        let content = UNMutableNotificationContent()
+        content.title = kind.title
+        content.subtitle = sourceDisplayName(task.source)
+        content.body = body(for: kind, task: task)
+        content.sound = .default
+        content.userInfo = [
+            taskNotificationSourceKey: task.source,
+            taskNotificationIDKey: task.id,
+        ]
+
+        // Include source as well as session ID so two agents with the same ID
+        // never replace or route each other's banner.
+        let requestID = "task-\(kind.identifierComponent)-\(task.source):\(task.id)"
+        let request = UNNotificationRequest(identifier: requestID, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error {
-                Self.log.error("Add completed notification failed: \(String(describing: error))")
+                let nsError = error as NSError
+                taskNotifierLog.error("Adding notification failed: domain=\(nsError.domain, privacy: .public) code=\(nsError.code) description=\(nsError.localizedDescription, privacy: .public)")
             }
         }
     }
 
-    private func postWaitingNotification(task: AgentTask) {
-        guard Self.hasNotificationSupport else {
-            Self.log.debug("(skip) →waiting for \(task.id) — no .app bundle")
-            return
-        }
-        let content = UNMutableNotificationContent()
-        content.title = "Task Needs Input"
-        // Manus puts the prompt text in `waitingMessage`; fall back to
-        // the title if the connector hasn't surfaced one.
-        content.body = task.waitingMessage ?? task.title
-        content.userInfo = ["taskURL": task.taskURL]
-        content.sound = .default
-
-        let id = "task-waiting-\(task.id)"
-        let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error {
-                Self.log.error("Add waiting notification failed: \(String(describing: error))")
-            }
+    private func body(for kind: TaskNotificationKind, task: AgentTask) -> String {
+        switch kind {
+        case .waiting:
+            return task.waitingMessage ?? task.currentPhase ?? task.title
+        case .failed:
+            return task.currentPhase ?? task.title
+        case .completed:
+            return task.title
         }
     }
 
-    // MARK: - UNUserNotificationCenterDelegate
+    private func sourceDisplayName(_ source: String) -> String {
+        if source == "manus" { return "Manus" }
+        return LocalAgentRegistry.descriptor(for: source)?.displayName ?? source
+    }
 
-    /// Show the banner even when our app is foreground — though as an
-    /// `.accessory` policy app we virtually never are.
     nonisolated public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -196,18 +231,22 @@ public final class TaskNotifier: NSObject, UNUserNotificationCenterDelegate {
         completionHandler([.banner, .sound])
     }
 
-    /// User clicked the banner → open the task's URL in the default
-    /// browser. Banners with no URL (shouldn't happen, defensive) are
-    /// silently dismissed.
+    /// Clicking a banner opens the island, scrolls the referenced task into
+    /// view, and highlights it. The user can then inspect the state before a
+    /// deliberate card click jumps back to the source session.
     nonisolated public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
-        if let urlString = userInfo["taskURL"] as? String,
-           let url = URL(string: urlString) {
-            NSWorkspace.shared.open(url)
+        if let source = userInfo[taskNotificationSourceKey] as? String,
+           let id = userInfo[taskNotificationIDKey] as? String {
+            let identity = TaskIdentity(source: source, id: id)
+            Task { @MainActor in
+                IslandCoordinator.shared.expand(highlighting: identity)
+                NSApp.activate(ignoringOtherApps: true)
+            }
         }
         completionHandler()
     }

--- a/IslandAppLib/StatusBar/StatusItemController.swift
+++ b/IslandAppLib/StatusBar/StatusItemController.swift
@@ -48,7 +48,8 @@ public final class StatusItemController: NSObject, NSMenuDelegate {
         if running > 0 { headline += " — \(running) 个任务进行中" }
         if waiting > 0 { headline += ",\(waiting) 个等待输入" }
         menu.addItem(disabledItem(headline))
-        menu.addItem(disabledItem("本地管线:Claude Code / Codex / Cursor"))
+        let localAgents = LocalAgentRegistry.all.map(\.displayName).joined(separator: " / ")
+        menu.addItem(disabledItem("本地管线:\(localAgents)"))
         menu.addItem(disabledItem("Manus:\(manusStatusText(store))"))
 
         menu.addItem(.separator())

--- a/IslandAppLib/Theme/AgentBrand.swift
+++ b/IslandAppLib/Theme/AgentBrand.swift
@@ -32,6 +32,7 @@ enum AgentBrand {
         case "claude-code": return "C"
         case "codex":       return "Cx"
         case "cursor":      return "Cu"
+        case "gemini-cli":  return "G"
         default:            return String(source.prefix(1)).uppercased()
         }
     }
@@ -79,7 +80,7 @@ struct AgentLogoBadge: View {
 #if PREVIEWS && DEBUG
 #Preview("Agent logo badges") {
     HStack(spacing: 10) {
-        ForEach(["claude-code", "codex", "cursor", "manus", "opencode"], id: \.self) {
+        ForEach(["claude-code", "codex", "cursor", "gemini-cli", "manus", "opencode"], id: \.self) {
             AgentLogoBadge(source: $0)
         }
     }

--- a/IslandAppLib/Theme/Animations.swift
+++ b/IslandAppLib/Theme/Animations.swift
@@ -1,15 +1,44 @@
 import SwiftUI
 
-/// Animation tokens. See CLAUDE_CLIENT.md §5.
+/// Product-wide motion tokens.
+///
+/// Keep spatial changes on the `smooth` / `snappy` family so velocity is
+/// continuous when several pieces move together. Opacity changes are kept
+/// shorter: the island should feel responsive first, expressive second.
 enum Motion {
-    /// Panel expand/collapse spring.
-    static let expand = Animation.spring(response: 0.6, dampingFraction: 0.72)
+    /// Large bar ↔ panel geometry change. No overshoot: the silhouette
+    /// grows almost an order of magnitude in height, where bounce reads as
+    /// window wobble rather than tactility.
+    static let islandMorph = Animation.smooth(duration: 0.38, extraBounce: 0)
+    /// Small hover and press geometry changes can carry a hint of energy.
+    static let hover = Animation.snappy(duration: 0.22, extraBounce: 0.08)
+    /// Content enters after its containing surface has begun to settle.
+    static let contentReveal = Animation.smooth(duration: 0.26, extraBounce: 0)
+    /// Task-list and empty-state height changes.
+    static let layout = Animation.smooth(duration: 0.32, extraBounce: 0)
+    /// Welcome Tour page choreography.
+    static let tourStep = Animation.smooth(duration: 0.42, extraBounce: 0)
+    /// Welcome Tour's persistent island illustration changing state.
+    static let tourHero = Animation.spring(response: 0.48, dampingFraction: 0.86)
+    /// Tiny controls should acknowledge immediately.
+    static let press = Animation.easeOut(duration: 0.09)
     /// Color cross-fade between states.
-    static let colorTransition = Animation.easeInOut(duration: 0.25)
+    static let colorTransition = Animation.easeInOut(duration: 0.22)
     /// Running breathing loop (2s).
     static let runningBreath = Animation.easeInOut(duration: 2).repeatForever(autoreverses: true)
     /// Waiting pulse loop (1s).
     static let waitingPulse = Animation.easeInOut(duration: 1).repeatForever(autoreverses: true)
     /// Waiting ripple expansion (1.5s).
     static let waitingRipple = Animation.easeOut(duration: 1.5).repeatForever(autoreverses: false)
+
+    /// Accessibility helper for one-shot transitions. Call sites retain the
+    /// same state changes while users who request reduced motion get a short
+    /// dissolve instead of spatial travel.
+    static func respectingReducedMotion(
+        _ reduceMotion: Bool,
+        preferred: Animation,
+        fallbackDuration: Double = 0.14
+    ) -> Animation {
+        reduceMotion ? .easeOut(duration: fallbackDuration) : preferred
+    }
 }

--- a/IslandAppLib/Theme/Colors.swift
+++ b/IslandAppLib/Theme/Colors.swift
@@ -6,9 +6,18 @@ enum Palette {
     // Surfaces
     static let notchBlack   = Color(hex: 0x000000)
     static let capsuleBlack = Color(hex: 0x0A0A0A)
-    static let cardBg       = Color(hex: 0x141414)
-    static let cardHover    = Color(hex: 0x1A1A1A)
-    static let divider      = Color.white.opacity(0.06)
+    static let islandTop    = Color(hex: 0x101218)
+    static let islandBottom = Color(hex: 0x050506)
+    static let cardBg       = Color(hex: 0x14161B)
+    static let cardHover    = Color(hex: 0x1B1E25)
+    static let divider      = Color.white.opacity(0.075)
+
+    // Welcome Tour
+    static let tourCanvas   = Color(hex: 0x08090D)
+    static let tourPanel    = Color(hex: 0x101218)
+    static let tourElevated = Color(hex: 0x171A21)
+    static let tourAccent   = Color(hex: 0x7C8CFF)
+    static let tourViolet   = Color(hex: 0x9B7BFF)
 
     // States
     static let stateIdle      = Color(hex: 0x4A4A4A)

--- a/IslandAppLib/Theme/Interaction.swift
+++ b/IslandAppLib/Theme/Interaction.swift
@@ -39,7 +39,64 @@ struct PressableButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .scaleEffect(configuration.isPressed ? pressedScale : 1)
-            .opacity(configuration.isPressed ? 0.85 : 1)
-            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+            .opacity(configuration.isPressed ? 0.82 : 1)
+            .animation(Motion.press, value: configuration.isPressed)
+    }
+}
+
+/// High-contrast action used by the Welcome Tour. The fill, border and
+/// shadow all react together, which makes the control feel like one solid
+/// material instead of an animated label on a static rectangle.
+struct TourPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 18)
+            .frame(height: 40)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [Palette.tourAccent, Palette.tourViolet],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .stroke(Color.white.opacity(0.22), lineWidth: 0.75)
+                    )
+                    .shadow(
+                        color: Palette.tourAccent.opacity(configuration.isPressed ? 0.16 : 0.28),
+                        radius: configuration.isPressed ? 5 : 11,
+                        y: configuration.isPressed ? 1 : 4
+                    )
+            )
+            .scaleEffect(configuration.isPressed ? 0.975 : 1)
+            .opacity(isEnabled ? 1 : 0.45)
+            .animation(Motion.press, value: configuration.isPressed)
+    }
+}
+
+struct TourSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(.white.opacity(configuration.isPressed ? 0.6 : 0.78))
+            .padding(.horizontal, 15)
+            .frame(height: 40)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(Color.white.opacity(configuration.isPressed ? 0.05 : 0.075))
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .stroke(Color.white.opacity(0.09), lineWidth: 0.75)
+                    )
+            )
+            .scaleEffect(configuration.isPressed ? 0.975 : 1)
+            .animation(Motion.press, value: configuration.isPressed)
     }
 }

--- a/IslandAppLib/Views/Island/IslandRootView.swift
+++ b/IslandAppLib/Views/Island/IslandRootView.swift
@@ -105,6 +105,7 @@ struct IslandRootView: View {
                 tasks: store.tasks,
                 connectionStatus: store.connectionStatus,
                 layout: baseLayout,
+                highlightedTask: coordinator.highlightedTask,
                 onTaskTap: handleTaskTap,
                 onSettingsTap: handleSettingsTap,
                 onConnectTap: handleConnectTap,
@@ -250,7 +251,7 @@ struct IslandRootView: View {
         if baseLayout.hasNotch {
             NotchBarView(
                 state: effectiveBarState,
-                taskCount: barTaskCount,
+                summary: taskStatusSummary,
                 title: barTitle,
                 layout: barLayoutForContent,
                 showsContent: true,
@@ -273,10 +274,7 @@ struct IslandRootView: View {
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text("\(barTaskCount)")
-                .font(Typo.barBadge)
-                .foregroundStyle(.white.opacity(0.88))
-                .monospacedDigit()
+            CompactTaskStatusSummary(summary: taskStatusSummary)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 3)
                 .background(
@@ -293,8 +291,8 @@ struct IslandRootView: View {
         )
     }
 
-    private var barTaskCount: Int {
-        store.tasks.count
+    private var taskStatusSummary: TaskStatusSummary {
+        TaskStatusSummary(tasks: store.tasks)
     }
 
     private var barTitle: String {
@@ -357,7 +355,8 @@ struct IslandRootView: View {
     }
 
     private func handleTaskTap(_ task: AgentTask) {
-        store.openTaskInBrowser(id: task.id)
+        coordinator.clearHighlight()
+        store.jumpToTask(task)
         coordinator.collapse()
     }
 
@@ -373,5 +372,6 @@ struct IslandRootView: View {
 
     private func handleConnectTap() {
         coordinator.collapse()
+        NotificationCenter.default.post(name: .islandOpenSettingsRequested, object: nil)
     }
 }

--- a/IslandAppLib/Views/NotchBar/NotchBarView.swift
+++ b/IslandAppLib/Views/NotchBar/NotchBarView.swift
@@ -12,7 +12,7 @@ import IslandCore
 ///   sitting `topMargin` below the screen edge.
 struct NotchBarView: View {
     let state: BarState
-    let taskCount: Int
+    let summary: TaskStatusSummary
     var title: String = "No tasks"
     let layout: NotchMetrics.Layout
     /// Whether to show the status dot + count inside the bar. Normal
@@ -112,10 +112,7 @@ struct NotchBarView: View {
                     .frame(width: layout.notchWidth, height: layout.menuBarHeight)
 
                 HStack(spacing: 6) {
-                    Text("\(taskCount)")
-                        .font(Typo.barCount)
-                        .foregroundStyle(.white.opacity(0.85))
-                        .monospacedDigit()
+                    CompactTaskStatusSummary(summary: summary)
                     Spacer(minLength: 0)
                 }
                 .padding(.horizontal, NotchMetrics.sideInset)
@@ -136,10 +133,7 @@ struct NotchBarView: View {
                     .truncationMode(.tail)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                Text("\(taskCount)")
-                    .font(Typo.barBadge)
-                    .foregroundStyle(.white.opacity(0.82))
-                    .monospacedDigit()
+                CompactTaskStatusSummary(summary: summary)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 4)
                     .background(
@@ -195,7 +189,14 @@ private let plainLayout = NotchMetrics.Layout(
     VStack(spacing: 18) {
         ForEach(barPreviewCases, id: \.label) { sample in
             VStack(spacing: 6) {
-                NotchBarView(state: sample.state, taskCount: sample.count, layout: notchedLayout)
+                NotchBarView(
+                    state: sample.state,
+                    summary: .init(running: sample.state == .running ? sample.count : 0,
+                                   waiting: sample.state == .waiting ? sample.count : 0,
+                                   failed: sample.state == .failed ? sample.count : 0,
+                                   completed: sample.state == .completed ? sample.count : 0),
+                    layout: notchedLayout
+                )
                 Text(sample.label)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -210,7 +211,14 @@ private let plainLayout = NotchMetrics.Layout(
     VStack(spacing: 14) {
         ForEach(barPreviewCases, id: \.label) { sample in
             VStack(spacing: 6) {
-                NotchBarView(state: sample.state, taskCount: sample.count, layout: plainLayout)
+                NotchBarView(
+                    state: sample.state,
+                    summary: .init(running: sample.state == .running ? sample.count : 0,
+                                   waiting: sample.state == .waiting ? sample.count : 0,
+                                   failed: sample.state == .failed ? sample.count : 0,
+                                   completed: sample.state == .completed ? sample.count : 0),
+                    layout: plainLayout
+                )
                 Text(sample.label)
                     .font(.caption2)
                     .foregroundStyle(.secondary)

--- a/IslandAppLib/Views/NotchBar/TaskStatusSummary.swift
+++ b/IslandAppLib/Views/NotchBar/TaskStatusSummary.swift
@@ -1,0 +1,91 @@
+import IslandCore
+import SwiftUI
+
+/// Compact multi-session snapshot for the collapsed island. Active states are
+/// shown together (waiting, failed, running); completed is shown only when no
+/// task is active, keeping the capsule useful without turning it into a row of
+/// counters.
+struct TaskStatusSummary: Equatable {
+    struct Segment: Equatable, Identifiable {
+        let status: TaskStatus
+        let count: Int
+
+        var id: String { status.rawValue }
+    }
+
+    let running: Int
+    let waiting: Int
+    let failed: Int
+    let completed: Int
+
+    init(tasks: [AgentTask]) {
+        running = tasks.count(where: { $0.status == .running })
+        waiting = tasks.count(where: { $0.status == .waiting })
+        failed = tasks.count(where: { $0.status == .failed })
+        completed = tasks.count(where: { $0.status == .completed })
+    }
+
+    init(running: Int = 0, waiting: Int = 0, failed: Int = 0, completed: Int = 0) {
+        self.running = running
+        self.waiting = waiting
+        self.failed = failed
+        self.completed = completed
+    }
+
+    var total: Int { running + waiting + failed + completed }
+
+    var segments: [Segment] {
+        var active: [Segment] = []
+        if waiting > 0 { active.append(.init(status: .waiting, count: waiting)) }
+        if failed > 0 { active.append(.init(status: .failed, count: failed)) }
+        if running > 0 { active.append(.init(status: .running, count: running)) }
+        if !active.isEmpty { return active }
+        if completed > 0 { return [.init(status: .completed, count: completed)] }
+        return []
+    }
+
+    var accessibilityLabel: String {
+        guard total > 0 else { return "No tasks" }
+        var parts: [String] = []
+        if waiting > 0 { parts.append("\(waiting) waiting") }
+        if failed > 0 { parts.append("\(failed) failed") }
+        if running > 0 { parts.append("\(running) running") }
+        if completed > 0 { parts.append("\(completed) completed") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+struct CompactTaskStatusSummary: View {
+    let summary: TaskStatusSummary
+
+    var body: some View {
+        HStack(spacing: 7) {
+            if summary.segments.isEmpty {
+                Text("0")
+                    .foregroundStyle(.white.opacity(0.55))
+            } else {
+                ForEach(summary.segments) { segment in
+                    HStack(spacing: 3) {
+                        Text("\(segment.count)")
+                            .foregroundStyle(.white.opacity(0.9))
+                        Image(systemName: symbol(for: segment.status))
+                            .foregroundStyle(segment.status.color)
+                    }
+                }
+            }
+        }
+        .font(Typo.barBadge)
+        .monospacedDigit()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(summary.accessibilityLabel)
+    }
+
+    private func symbol(for status: TaskStatus) -> String {
+        switch status {
+        case .running:   return "play.fill"
+        case .waiting:   return "pause.fill"
+        case .failed:    return "exclamationmark"
+        case .completed: return "checkmark"
+        }
+    }
+}

--- a/IslandAppLib/Views/NotchPanel/NotchPanelView.swift
+++ b/IslandAppLib/Views/NotchPanel/NotchPanelView.swift
@@ -9,6 +9,7 @@ struct NotchPanelView: View {
     /// Layout snapshot of the host display so the panel knows whether to
     /// reserve space for the hardware notch at the top.
     let layout: NotchMetrics.Layout
+    let highlightedTask: TaskIdentity?
     let onTaskTap: (AgentTask) -> Void
     let onSettingsTap: () -> Void
     let onConnectTap: () -> Void
@@ -140,14 +141,28 @@ struct NotchPanelView: View {
         if tasks.isEmpty {
             emptyState
         } else {
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(spacing: 6) {
-                    ForEach(tasks) { task in
-                        TaskCard(task: task, onTap: { onTaskTap(task) })
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack(spacing: 6) {
+                        ForEach(tasks, id: \.identity) { task in
+                            TaskCard(
+                                task: task,
+                                isHighlighted: task.identity == highlightedTask,
+                                onTap: { onTaskTap(task) }
+                            )
+                            .id(task.identity)
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 8)
+                }
+                .onChange(of: highlightedTask, initial: true) { _, identity in
+                    guard let identity,
+                          tasks.contains(where: { $0.identity == identity }) else { return }
+                    withAnimation(.easeOut(duration: 0.25)) {
+                        proxy.scrollTo(identity, anchor: .center)
                     }
                 }
-                .padding(.horizontal, 10)
-                .padding(.bottom, 8)
             }
             .frame(maxHeight: 320)
         }
@@ -234,6 +249,7 @@ private let previewLayoutNotched = NotchMetrics.Layout(
         tasks: TaskStore.previewTasks,
         connectionStatus: .connected,
         layout: previewLayoutNoNotch,
+        highlightedTask: nil,
         onTaskTap: { _ in },
         onSettingsTap: {},
         onConnectTap: {}
@@ -247,6 +263,7 @@ private let previewLayoutNotched = NotchMetrics.Layout(
         tasks: TaskStore.previewTasks,
         connectionStatus: .connected,
         layout: previewLayoutNotched,
+        highlightedTask: TaskStore.previewTasks.first?.identity,
         onTaskTap: { _ in },
         onSettingsTap: {},
         onConnectTap: {}
@@ -260,6 +277,7 @@ private let previewLayoutNotched = NotchMetrics.Layout(
         tasks: [],
         connectionStatus: .reconnecting,
         layout: previewLayoutNoNotch,
+        highlightedTask: nil,
         onTaskTap: { _ in },
         onSettingsTap: {},
         onConnectTap: {}

--- a/IslandAppLib/Views/NotchPanel/TaskCard.swift
+++ b/IslandAppLib/Views/NotchPanel/TaskCard.swift
@@ -7,6 +7,7 @@ import IslandCore
 /// chevron. Running tasks get a 2pt animated progress bar at the bottom.
 struct TaskCard: View {
     let task: AgentTask
+    var isHighlighted: Bool = false
     let onTap: () -> Void
 
     @State private var isHovering = false
@@ -58,10 +59,17 @@ struct TaskCard: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(isHovering ? Palette.cardHover : Palette.cardBg)
+                    .fill(cardBackground)
                     // Ease the highlight in/out — the hard cut read as
                     // flicker when skimming the cursor down the list.
                     .animation(.easeOut(duration: 0.12), value: isHovering)
+            }
+            .overlay {
+                if isHighlighted {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(task.status.color.opacity(0.9), lineWidth: 1.5)
+                        .shadow(color: task.status.color.opacity(0.55), radius: 7)
+                }
             }
             .overlay(alignment: .bottom) {
                 if task.status == .running {
@@ -76,6 +84,7 @@ struct TaskCard: View {
         .onHover { isHovering = $0 }
         .pointingHandCursor()
         .onReceive(timer) { tick = $0 }
+        .animation(.easeOut(duration: 0.2), value: isHighlighted)
     }
 
     // MARK: - Pieces
@@ -84,6 +93,13 @@ struct TaskCard: View {
         // Real brand logo (template PNG) with monogram fallback —
         // see AgentBrand.
         AgentLogoBadge(source: task.source)
+    }
+
+    private var cardBackground: Color {
+        if isHighlighted {
+            return task.status.color.opacity(0.18)
+        }
+        return isHovering ? Palette.cardHover : Palette.cardBg
     }
 
     private var durationString: String {

--- a/IslandAppLib/Views/Onboarding/OnboardingView.swift
+++ b/IslandAppLib/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,319 @@
+import IslandCore
+import SwiftUI
+
+struct OnboardingView: View {
+    let onFinish: () -> Void
+
+    @State private var step = 0
+    @AppStorage(TaskNotificationPreferences.attentionRequiredKey)
+    private var attentionRequired = true
+    @AppStorage(TaskNotificationPreferences.completionsKey)
+    private var completions = false
+
+    private let stepCount = 3
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                switch step {
+                case 0: welcomeStep.transition(stepTransition)
+                case 1: connectionsStep.transition(stepTransition)
+                default: notificationsStep.transition(stepTransition)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 42)
+            .padding(.top, 36)
+
+            footer
+        }
+        .frame(width: 620, height: 520)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var stepTransition: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: .trailing).combined(with: .opacity),
+            removal: .move(edge: .leading).combined(with: .opacity)
+        )
+    }
+
+    private var welcomeStep: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(Color.black)
+                    .frame(width: 286, height: 74)
+                    .shadow(color: Color.blue.opacity(0.22), radius: 18)
+
+                HStack(spacing: 14) {
+                    Circle()
+                        .fill(Palette.stateWaiting)
+                        .frame(width: 12, height: 12)
+                    Text("1")
+                    Image(systemName: "pause.fill")
+                        .foregroundStyle(Palette.stateWaiting)
+                    Text("2")
+                    Image(systemName: "play.fill")
+                        .foregroundStyle(Palette.stateRunning)
+                }
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.white)
+            }
+
+            VStack(spacing: 9) {
+                Text("Your AI agents, one island")
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                Text("See every active session at a glance—without keeping terminal windows in view.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 430)
+            }
+
+            HStack(spacing: 22) {
+                valuePoint("Detect blockers", symbol: "exclamationmark.bubble")
+                valuePoint("Stay focused", symbol: "eye.slash")
+                valuePoint("Jump back", symbol: "arrow.turn.down.right")
+            }
+
+            Spacer()
+        }
+    }
+
+    private var connectionsStep: some View {
+        VStack(spacing: 18) {
+            VStack(spacing: 7) {
+                Text("Connect your local agents")
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                Text("Enable the tools you use. Dev Island only adds its own local hook entries and preserves the rest of each config file.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 500)
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                ForEach(LocalAgentRegistry.all, id: \.source) { descriptor in
+                    OnboardingAgentRow(descriptor: descriptor)
+                }
+            }
+
+            Text("You can change these connections anytime in Settings.")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var notificationsStep: some View {
+        VStack(spacing: 22) {
+            VStack(spacing: 7) {
+                Text("Come back only when it matters")
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                Text("A notification opens the island on the exact task. Click its card to return to the source app or terminal.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 480)
+            }
+
+            VStack(spacing: 0) {
+                onboardingNotificationToggle(
+                    title: "Attention required",
+                    subtitle: "Waiting for input and failures",
+                    symbol: "bell.badge.fill",
+                    tint: .orange,
+                    isOn: $attentionRequired
+                )
+
+                Divider().padding(.leading, 58)
+
+                onboardingNotificationToggle(
+                    title: "Task completed",
+                    subtitle: "Optional—off by default to reduce noise",
+                    symbol: "checkmark.circle.fill",
+                    tint: .green,
+                    isOn: $completions
+                )
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+
+            VStack(alignment: .leading, spacing: 12) {
+                flowRow("1", "Agent needs you", color: Palette.stateWaiting)
+                flowRow("2", "Click the notification to inspect it", color: .secondary)
+                flowRow("3", "Click the card to jump back", color: Palette.stateRunning)
+            }
+            .frame(maxWidth: 390, alignment: .leading)
+
+            Spacer(minLength: 0)
+        }
+        .onChange(of: attentionRequired) { _, enabled in
+            if enabled { TaskNotifier.shared.refreshAuthorizationIfNeeded() }
+        }
+        .onChange(of: completions) { _, enabled in
+            if enabled { TaskNotifier.shared.refreshAuthorizationIfNeeded() }
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 7) {
+                ForEach(0..<stepCount, id: \.self) { index in
+                    Capsule()
+                        .fill(index == step ? Color.accentColor : Color.secondary.opacity(0.25))
+                        .frame(width: index == step ? 20 : 7, height: 7)
+                        .animation(.easeOut(duration: 0.2), value: step)
+                }
+            }
+
+            HStack {
+                Button("Skip for now", action: onFinish)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if step > 0 {
+                    Button("Back") { move(to: step - 1) }
+                }
+
+                Button(step == stepCount - 1 ? "Start using Dev Island" : "Continue") {
+                    if step == stepCount - 1 {
+                        onFinish()
+                    } else {
+                        move(to: step + 1)
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(.horizontal, 28)
+        .padding(.bottom, 24)
+    }
+
+    private func move(to newStep: Int) {
+        withAnimation(.easeInOut(duration: 0.28)) {
+            step = newStep
+        }
+    }
+
+    private func valuePoint(_ title: String, symbol: String) -> some View {
+        VStack(spacing: 7) {
+            Image(systemName: symbol)
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(Color.accentColor)
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+        }
+        .frame(width: 110)
+    }
+
+    private func onboardingNotificationToggle(
+        title: String,
+        subtitle: String,
+        symbol: String,
+        tint: Color,
+        isOn: Binding<Bool>
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            HStack(spacing: 12) {
+                Image(systemName: symbol)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 24)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title).font(.system(size: 13, weight: .semibold))
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .toggleStyle(.switch)
+        .padding(16)
+    }
+
+    private func flowRow(_ number: String, _ text: String, color: Color) -> some View {
+        HStack(spacing: 11) {
+            Text(number)
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+                .frame(width: 20, height: 20)
+                .background(Circle().fill(color))
+            Text(text)
+                .font(.system(size: 12, weight: .medium))
+        }
+    }
+}
+
+private struct OnboardingAgentRow: View {
+    let descriptor: LocalAgentDescriptor
+
+    @State private var installed = false
+    @State private var errorMessage: String?
+
+    private var installer: LocalHooksInstaller { .init(descriptor) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 10) {
+                AgentLogoBadge(
+                    source: descriptor.source,
+                    size: 30,
+                    ink: .primary,
+                    badge: Color.primary.opacity(0.06)
+                )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(descriptor.displayName)
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(installed ? "Ready for new sessions" : "Not enabled")
+                        .font(.system(size: 10))
+                        .foregroundStyle(installed ? Color.green : .secondary)
+                }
+                Spacer()
+                Button(installed ? "Enabled" : "Enable") {
+                    enable()
+                }
+                .disabled(installed)
+                .controlSize(.small)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(13)
+        .frame(maxWidth: .infinity, minHeight: 62, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .onAppear { installed = installer.isInstalled() }
+    }
+
+    private func enable() {
+        do {
+            try installer.install()
+            installed = true
+            errorMessage = nil
+        } catch {
+            errorMessage = "Couldn’t update \(descriptor.configPath): \(error.localizedDescription)"
+        }
+    }
+}
+
+#if PREVIEWS
+#Preview("Onboarding") {
+    OnboardingView(onFinish: {})
+}
+#endif

--- a/IslandAppLib/Views/Settings/SettingsView.swift
+++ b/IslandAppLib/Views/Settings/SettingsView.swift
@@ -14,10 +14,12 @@ import ServiceManagement
 /// Bound directly to `TaskStore.shared` so the Manus row's status dot
 /// reflects live `apiKeyStatus` / `connectionStatus` without manual
 /// notification plumbing.
-struct SettingsView: View {
+public struct SettingsView: View {
     @State private var store = TaskStore.shared
 
-    var body: some View {
+    public init() {}
+
+    public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
                 header
@@ -25,6 +27,8 @@ struct SettingsView: View {
                 ConnectedServicesSection(store: store)
 
                 GeneralSection()
+
+                NotificationsSection()
 
                 Divider()
 
@@ -50,6 +54,9 @@ struct SettingsView: View {
 
     private var footer: some View {
         HStack {
+            Button("View Welcome Tour") {
+                NotificationCenter.default.post(name: .islandOpenOnboardingRequested, object: nil)
+            }
             Spacer()
             Button("Quit Island") {
                 NSApp.terminate(nil)
@@ -59,22 +66,51 @@ struct SettingsView: View {
     }
 }
 
-// MARK: - Connected Services
+// MARK: - Notifications
 
-private struct ConnectedServicesSection: View {
-    let store: TaskStore
+private struct NotificationsSection: View {
+    @AppStorage(TaskNotificationPreferences.attentionRequiredKey)
+    private var attentionRequired = true
+
+    @AppStorage(TaskNotificationPreferences.completionsKey)
+    private var completions = false
+
+    @State private var authorizationIssue: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            sectionTitle("Connected Services")
+            sectionTitle("Notifications")
 
             VStack(spacing: 0) {
-                ManusServiceRow(store: store)
-                // Local agents come straight from the registry: adding an
-                // agent to LocalAgentRegistry adds its Settings row.
-                ForEach(LocalAgentRegistry.all, id: \.source) { descriptor in
-                    rowDivider
-                    LocalAgentServiceRow(descriptor: descriptor)
+                notificationToggle(
+                    title: "Attention Required",
+                    subtitle: "Notify when a task needs input or fails.",
+                    isOn: $attentionRequired
+                )
+
+                Divider().padding(.leading, 16)
+
+                notificationToggle(
+                    title: "Task Completed",
+                    subtitle: "Optionally notify when a task finishes.",
+                    isOn: $completions
+                )
+
+                if notificationsEnabled, let authorizationIssue {
+                    Divider().padding(.leading, 16)
+                    HStack(spacing: 10) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text(authorizationIssue)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Open System Settings") {
+                            openNotificationSettings()
+                        }
+                        .controlSize(.small)
+                    }
+                    .padding(16)
                 }
             }
             .background(
@@ -82,6 +118,132 @@ private struct ConnectedServicesSection: View {
                     .fill(Color(nsColor: .controlBackgroundColor))
             )
         }
+        .onChange(of: attentionRequired) { _, enabled in
+            if enabled { TaskNotifier.shared.refreshAuthorizationIfNeeded() }
+        }
+        .onChange(of: completions) { _, enabled in
+            if enabled { TaskNotifier.shared.refreshAuthorizationIfNeeded() }
+        }
+        .onAppear {
+            authorizationIssue = TaskNotifier.shared.authorizationIssue
+            TaskNotifier.shared.refreshAuthorizationState()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .islandNotificationAuthorizationChanged)) { _ in
+            authorizationIssue = TaskNotifier.shared.authorizationIssue
+        }
+    }
+
+    private var notificationsEnabled: Bool {
+        attentionRequired || completions
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func notificationToggle(
+        title: String,
+        subtitle: String,
+        isOn: Binding<Bool>
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .toggleStyle(.switch)
+        .padding(16)
+    }
+}
+
+// MARK: - Connected Services
+
+private struct ConnectedServicesSection: View {
+    let store: TaskStore
+    @State private var searchText = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            sectionTitle("Agent Connections")
+
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search agents", text: $searchText)
+                    .textFieldStyle(.plain)
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+
+            if showsManus {
+                groupLabel("Cloud Agent")
+                ManusServiceRow(store: store)
+                    .background(serviceGroupBackground)
+            }
+
+            if !filteredLocalAgents.isEmpty {
+                groupLabel("Local Agents")
+                VStack(spacing: 0) {
+                    // Local agents come straight from the registry: adding an
+                    // agent to LocalAgentRegistry adds its Settings row.
+                    ForEach(filteredLocalAgents, id: \.source) { descriptor in
+                        if descriptor.source != filteredLocalAgents.first?.source { rowDivider }
+                        LocalAgentServiceRow(descriptor: descriptor)
+                    }
+                }
+                .background(serviceGroupBackground)
+            }
+
+            if !showsManus && filteredLocalAgents.isEmpty {
+                ContentUnavailableView(
+                    "No matching agents",
+                    systemImage: "magnifyingglass",
+                    description: Text("Try a name such as Codex, Claude, Cursor, or Gemini.")
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+            }
+        }
+    }
+
+    private var normalizedSearch: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private var showsManus: Bool {
+        normalizedSearch.isEmpty || "manus cloud".contains(normalizedSearch)
+    }
+
+    private var filteredLocalAgents: [LocalAgentDescriptor] {
+        guard !normalizedSearch.isEmpty else { return LocalAgentRegistry.all }
+        return LocalAgentRegistry.all.filter { descriptor in
+            [descriptor.displayName, descriptor.source, descriptor.settingsSubtitle]
+                .joined(separator: " ")
+                .lowercased()
+                .contains(normalizedSearch)
+        }
+    }
+
+    private var serviceGroupBackground: some View {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func groupLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.secondary)
     }
 
     private var rowDivider: some View {
@@ -101,7 +263,6 @@ private struct ManusServiceRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
-                statusDot
                 AgentLogoBadge(
                     source: "manus",
                     size: 24,
@@ -115,7 +276,10 @@ private struct ManusServiceRow: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                trailingControl
+                HStack(spacing: 8) {
+                    ServiceStatusBadge(label: badgeLabel, color: statusColor)
+                    trailingControl
+                }
             }
 
             // Show key entry when not configured / invalid. When valid,
@@ -133,18 +297,30 @@ private struct ManusServiceRow: View {
         .padding(16)
     }
 
-    @ViewBuilder
-    private var statusDot: some View {
-        Circle()
-            .fill(statusColor)
-            .frame(width: 8, height: 8)
-    }
-
     private var statusColor: Color {
         switch store.apiKeyStatus {
-        case .valid:        return .green
-        case .invalid:      return .red
+        case .valid:
+            switch store.connectionStatus {
+            case .connected: return .green
+            case .reconnecting, .degraded: return .orange
+            case .disconnected: return .red
+            }
+        case .invalid:       return .red
         case .notConfigured: return Color.secondary.opacity(0.5)
+        }
+    }
+
+    private var badgeLabel: String {
+        switch store.apiKeyStatus {
+        case .invalid: return "Needs attention"
+        case .notConfigured: return "Not connected"
+        case .valid:
+            switch store.connectionStatus {
+            case .connected: return "Connected"
+            case .reconnecting: return "Reconnecting"
+            case .degraded: return "Degraded"
+            case .disconnected: return "Disconnected"
+            }
         }
     }
 
@@ -245,9 +421,6 @@ private struct LocalAgentServiceRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
-                Circle()
-                    .fill(installed ? Color.green : Color.secondary.opacity(0.5))
-                    .frame(width: 8, height: 8)
                 AgentLogoBadge(
                     source: descriptor.source,
                     size: 24,
@@ -263,13 +436,19 @@ private struct LocalAgentServiceRow: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                if installed {
-                    Button("Disable", role: .destructive) {
-                        toggle({ try installer.uninstall() }, to: false)
-                    }
-                } else {
-                    Button("Enable") {
-                        toggle({ try installer.install() }, to: true)
+                HStack(spacing: 8) {
+                    ServiceStatusBadge(
+                        label: installed ? "Enabled" : "Not enabled",
+                        color: installed ? .green : Color.secondary.opacity(0.5)
+                    )
+                    if installed {
+                        Button("Disable", role: .destructive) {
+                            toggle({ try installer.uninstall() }, to: false)
+                        }
+                    } else {
+                        Button("Enable") {
+                            toggle({ try installer.install() }, to: true)
+                        }
                     }
                 }
             }
@@ -369,6 +548,29 @@ private func sectionTitle(_ text: String) -> some View {
         .font(.system(size: 12, weight: .semibold))
         .foregroundStyle(.secondary)
         .textCase(.uppercase)
+}
+
+private struct ServiceStatusBadge: View {
+    let label: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .lineLimit(1)
+        }
+        .font(.system(size: 10, weight: .medium))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .background(
+            Capsule(style: .continuous)
+                .fill(color.opacity(0.12))
+        )
+    }
 }
 
 #if PREVIEWS && DEBUG

--- a/IslandAppLib/Windows/IslandWindow.swift
+++ b/IslandAppLib/Windows/IslandWindow.swift
@@ -9,9 +9,9 @@ import IslandCore
 /// jankier than SwiftUI's own spring).
 ///
 /// **Click-through model.** This window is much taller than the actual
-/// visible silhouette (the bar's ~28pt vs. the window's 408pt allowance
-/// for the expanded panel). The empty area is fully transparent, but a
-/// transparent NSWindow still intercepts every mouse event in its frame
+/// visible silhouette (the bar's ~28pt vs. the window's allowance for a
+/// full-height expanded panel). The empty area is fully transparent, but
+/// a transparent NSWindow still intercepts every mouse event in its frame
 /// — that means clicks across the upper-middle of the screen get
 /// silently swallowed unless we opt out. We do that by polling the
 /// cursor position via a low-frequency timer and toggling

--- a/IslandAppLib/Windows/OnboardingWindow.swift
+++ b/IslandAppLib/Windows/OnboardingWindow.swift
@@ -1,0 +1,31 @@
+import AppKit
+import SwiftUI
+
+public extension Notification.Name {
+    static let islandOpenOnboardingRequested = Notification.Name("island.openOnboardingRequested")
+}
+
+public final class OnboardingWindow: NSWindow {
+    public static let completionKey = "island.didCompleteFirstLaunch"
+
+    public init(onFinish: @escaping () -> Void) {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: 520),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        title = "Welcome to Dev Island"
+        isReleasedWhenClosed = false
+        level = .normal
+        collectionBehavior = [.fullScreenAuxiliary]
+        contentView = NSHostingView(rootView: OnboardingView(onFinish: onFinish))
+        center()
+    }
+
+    public func bringToFront() {
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+}

--- a/IslandAppLibTests/Sources/IslandAppLibTests/TaskNotificationPolicyTests.swift
+++ b/IslandAppLibTests/Sources/IslandAppLibTests/TaskNotificationPolicyTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import IslandAppLib
+import IslandCore
+
+final class TaskNotificationPolicyTests: XCTestCase {
+    func testNewlyDiscoveredWaitingTaskDoesNotNotify() {
+        let transition = TaskTransition(task: task(.waiting), oldStatus: nil)
+
+        XCTAssertNil(TaskNotificationKind.decide(
+            for: transition,
+            attentionRequired: true,
+            completions: true
+        ))
+    }
+
+    func testWaitingAndFailureAreAttentionNotifications() {
+        let waiting = TaskTransition(task: task(.waiting), oldStatus: .running)
+        let failed = TaskTransition(task: task(.failed), oldStatus: .running)
+
+        XCTAssertEqual(TaskNotificationKind.decide(
+            for: waiting,
+            attentionRequired: true,
+            completions: false
+        ), .waiting)
+        XCTAssertEqual(TaskNotificationKind.decide(
+            for: failed,
+            attentionRequired: true,
+            completions: false
+        ), .failed)
+    }
+
+    func testAttentionToggleSuppressesWaitingAndFailure() {
+        for status: TaskStatus in [.waiting, .failed] {
+            let transition = TaskTransition(task: task(status), oldStatus: .running)
+            XCTAssertNil(TaskNotificationKind.decide(
+                for: transition,
+                attentionRequired: false,
+                completions: true
+            ))
+        }
+    }
+
+    func testCompletionIsOptIn() {
+        let transition = TaskTransition(task: task(.completed), oldStatus: .running)
+
+        XCTAssertNil(TaskNotificationKind.decide(
+            for: transition,
+            attentionRequired: true,
+            completions: false
+        ))
+        XCTAssertEqual(TaskNotificationKind.decide(
+            for: transition,
+            attentionRequired: true,
+            completions: true
+        ), .completed)
+    }
+
+    @MainActor
+    func testNotificationSelectionHighlightsTaskAndExpandsPanel() {
+        let identity = TaskIdentity(source: "codex", id: "session-1")
+        let coordinator = IslandCoordinator.shared
+        coordinator.collapse()
+
+        coordinator.expand(highlighting: identity)
+
+        XCTAssertEqual(coordinator.mode, .expanded)
+        XCTAssertEqual(coordinator.highlightedTask, identity)
+
+        coordinator.collapse()
+        XCTAssertNil(coordinator.highlightedTask)
+    }
+
+    private func task(_ status: TaskStatus) -> AgentTask {
+        AgentTask(
+            id: "session-1",
+            source: "codex",
+            title: "DevLand",
+            status: status,
+            createdAt: .now,
+            updatedAt: .now,
+            taskURL: "file:///tmp/DevLand"
+        )
+    }
+}

--- a/IslandAppLibTests/Sources/IslandAppLibTests/TaskStatusSummaryTests.swift
+++ b/IslandAppLibTests/Sources/IslandAppLibTests/TaskStatusSummaryTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import IslandAppLib
+import IslandCore
+
+final class TaskStatusSummaryTests: XCTestCase {
+    func testActiveSegmentsUseAttentionFirstOrder() {
+        let summary = TaskStatusSummary(running: 2, waiting: 1, failed: 1, completed: 4)
+
+        XCTAssertEqual(summary.segments.map(\.status), [.waiting, .failed, .running])
+        XCTAssertEqual(summary.segments.map(\.count), [1, 1, 2])
+    }
+
+    func testCompletedOnlyAppearsWhenNothingIsActive() {
+        XCTAssertEqual(
+            TaskStatusSummary(completed: 3).segments,
+            [.init(status: .completed, count: 3)]
+        )
+        XCTAssertTrue(TaskStatusSummary().segments.isEmpty)
+    }
+
+    func testAccessibilityLabelIncludesEveryState() {
+        let summary = TaskStatusSummary(running: 2, waiting: 1, failed: 1, completed: 4)
+
+        XCTAssertEqual(summary.accessibilityLabel, "1 waiting, 1 failed, 2 running, 4 completed")
+    }
+}

--- a/IslandCore/Sources/IslandCore/Models/AgentTask.swift
+++ b/IslandCore/Sources/IslandCore/Models/AgentTask.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+/// Globally unique identity for one task inside Dev Island.
+///
+/// Agent session IDs are only guaranteed to be unique within their source,
+/// so every UI lookup, notification payload, and jump-back action must carry
+/// both values. Keeping this as a typed value prevents a future caller from
+/// accidentally falling back to an ambiguous bare session ID.
+public struct TaskIdentity: Hashable, Codable, Sendable {
+    public let source: String
+    public let id: String
+
+    public init(source: String, id: String) {
+        self.source = source
+        self.id = id
+    }
+}
+
 public struct AgentTask: Identifiable, Hashable, Codable, Sendable {
     public let id: String
     public let source: String          // "manus" (future: "claude-code", "cursor")
@@ -31,6 +47,12 @@ public struct AgentTask: Identifiable, Hashable, Codable, Sendable {
         self.updatedAt = updatedAt
         self.taskURL = taskURL
         self.waitingMessage = waitingMessage
+    }
+
+    /// Stable cross-agent identity used by lists, notification routing, and
+    /// jump-back. `id` remains available for connector-facing APIs.
+    public var identity: TaskIdentity {
+        TaskIdentity(source: source, id: id)
     }
 }
 

--- a/IslandCore/Sources/IslandCore/Models/TaskTransition.swift
+++ b/IslandCore/Sources/IslandCore/Models/TaskTransition.swift
@@ -29,16 +29,12 @@ extension TaskTransition {
     /// source (the same CLI session-id string can legally exist on two
     /// different connectors).
     static func diff(old: [AgentTask], new: [AgentTask]) -> [TaskTransition] {
-        struct Key: Hashable {
-            let source: String
-            let id: String
-        }
-        var oldStatuses: [Key: TaskStatus] = [:]
+        var oldStatuses: [TaskIdentity: TaskStatus] = [:]
         for task in old {
-            oldStatuses[Key(source: task.source, id: task.id)] = task.status
+            oldStatuses[task.identity] = task.status
         }
         return new.compactMap { task in
-            let oldStatus = oldStatuses[Key(source: task.source, id: task.id)]
+            let oldStatus = oldStatuses[task.identity]
             guard oldStatus != task.status else { return nil }
             return TaskTransition(task: task, oldStatus: oldStatus)
         }

--- a/IslandCore/Sources/IslandCore/TaskStore.swift
+++ b/IslandCore/Sources/IslandCore/TaskStore.swift
@@ -90,10 +90,26 @@ public final class TaskStore {
         IslandLogger.store.info("API key cleared")
     }
 
-    public func openTaskInBrowser(id: String) {
-        guard let task = tasks.first(where: { $0.id == id }) else { return }
+    /// Resolve one task without assuming session IDs are globally unique.
+    public func task(with identity: TaskIdentity) -> AgentTask? {
+        tasks.first(where: { $0.identity == identity })
+    }
+
+    public func openTask(_ task: AgentTask) {
         guard let url = URL(string: task.taskURL) else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    public func openTaskInBrowser(source: String, id: String) {
+        guard let task = task(with: TaskIdentity(source: source, id: id)) else { return }
+        openTask(task)
+    }
+
+    /// Compatibility entry point for the v1.4 contract. It refuses an
+    /// ambiguous cross-agent ID instead of opening an arbitrary task.
+    public func openTaskInBrowser(id: String) {
+        guard let task = uniquelyMatchingTask(id: id) else { return }
+        openTask(task)
     }
 
     /// Jump back to the session behind a task (contract v1.4.0, J2).
@@ -101,29 +117,51 @@ public final class TaskStore {
     /// codex → Codex Desktop or a running terminal, claude-code → a running
     /// terminal); falls back to `openTaskInBrowser` behavior when no
     /// suitable app is running (local tasks → Finder, Manus → browser).
-    public func jumpToTask(id: String) {
-        guard let task = tasks.first(where: { $0.id == id }) else { return }
+    public func jumpToTask(_ task: AgentTask) {
         if SourceAppResolver.activateApp(for: task.source) {
-            IslandLogger.store.debug("jumpToTask(\(id)): activated \(task.source) host app")
+            IslandLogger.store.debug("jumpToTask(\(task.source), \(task.id)): activated host app")
             return
         }
-        openTaskInBrowser(id: id)
+        openTask(task)
+    }
+
+    public func jumpToTask(source: String, id: String) {
+        guard let task = task(with: TaskIdentity(source: source, id: id)) else { return }
+        jumpToTask(task)
+    }
+
+    /// Compatibility entry point for the v1.4 contract. New UI code should
+    /// pass the task (or source + id) so cross-agent collisions are impossible.
+    public func jumpToTask(id: String) {
+        guard let task = uniquelyMatchingTask(id: id) else { return }
+        jumpToTask(task)
     }
 
     public func stopTask(id: String) async throws {
-        guard let task = tasks.first(where: { $0.id == id }) else { return }
         // Only Manus tasks can be stopped remotely; local sessions
         // (Claude Code) are driven by their own CLI.
-        guard task.source == "manus", let connector = connectors.first else { return }
+        guard tasks.contains(where: { $0.source == "manus" && $0.id == id }),
+              let connector = connectors.first else { return }
         try await connector.stop(taskId: id)
         // Optimistically update status
         setTasks(tasks.map { t in
-            guard t.id == id else { return t }
+            guard t.source == "manus", t.id == id else { return t }
             var updated = t
             updated.status = .completed
             updated.updatedAt = Date.now
             return updated
         })
+    }
+
+    private func uniquelyMatchingTask(id: String) -> AgentTask? {
+        let matches = tasks.filter { $0.id == id }
+        guard matches.count == 1 else {
+            if matches.count > 1 {
+                IslandLogger.store.error("Ambiguous bare task id \(id); caller must include source")
+            }
+            return nil
+        }
+        return matches[0]
     }
 
     // MARK: - Internal (called by TunnelManager / PollingFallback)

--- a/IslandCoreTests/Sources/IslandCoreTests/TaskIdentityTests.swift
+++ b/IslandCoreTests/Sources/IslandCoreTests/TaskIdentityTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import IslandCore
+
+final class TaskIdentityTests: XCTestCase {
+    func testIdentityIncludesSource() {
+        let codex = task(source: "codex")
+        let cursor = task(source: "cursor")
+
+        XCTAssertNotEqual(codex.identity, cursor.identity)
+        XCTAssertEqual(Set([codex.identity, cursor.identity]).count, 2)
+    }
+
+    @MainActor
+    func testStoreResolvesSameSessionIDBySource() {
+        let codex = task(source: "codex")
+        let cursor = task(source: "cursor")
+        let store = TaskStore.mock(tasks: [codex, cursor])
+
+        XCTAssertEqual(store.task(with: codex.identity)?.source, "codex")
+        XCTAssertEqual(store.task(with: cursor.identity)?.source, "cursor")
+    }
+
+    private func task(source: String) -> AgentTask {
+        AgentTask(
+            id: "shared-session-id",
+            source: source,
+            title: source,
+            status: .running,
+            createdAt: .now,
+            updatedAt: .now,
+            taskURL: "file:///tmp/\(source)"
+        )
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -95,5 +95,10 @@ let package = Package(
             dependencies: ["IslandCore"],
             path: "IslandCoreTests/Sources/IslandCoreTests"
         ),
+        .testTarget(
+            name: "IslandAppLibTests",
+            dependencies: ["IslandAppLib", "IslandCore"],
+            path: "IslandAppLibTests/Sources/IslandAppLibTests"
+        ),
     ]
 )

--- a/docs/INTERFACE_CONTRACT.md
+++ b/docs/INTERFACE_CONTRACT.md
@@ -1,6 +1,6 @@
 # IslandCore Interface Contract
 
-> 最后更新: 2026-08-03 | 版本: v1.5.0
+> 最后更新: 2026-08-09 | 版本: v1.6.0
 > 变更流程: 改 TaskStore 公开 API 前更新此文档,commit 用 `[S][contract]` tag。
 
 ---
@@ -28,13 +28,21 @@ public final class TaskStore {
     public func clearAPIKey()
 
     /// 在浏览器中打开指定任务。
+    /// 裸 id 兼容入口仅在匹配唯一时执行;新代码应传 source 或 AgentTask。
     public func openTaskInBrowser(id: String)
+    public func openTaskInBrowser(source: String, id: String)
+    public func openTask(_ task: AgentTask)
+
+    /// 按全局身份解析任务。
+    public func task(with identity: TaskIdentity) -> AgentTask?
 
     /// 跳回任务所在的会话(v1.4.0 新增,J2 交付)。
     /// 能解析出来源 app 时做 app 级激活(cursor → Cursor.app);
     /// 解析不出或激活失败时回退到 openTaskInBrowser 的行为
     /// (本地任务 → Finder 打开项目目录,Manus → 浏览器)。
     public func jumpToTask(id: String)
+    public func jumpToTask(source: String, id: String)
+    public func jumpToTask(_ task: AgentTask)
 
     /// 通过 Manus API 停止任务。
     public func stopTask(id: String) async throws
@@ -64,7 +72,7 @@ public struct TaskTransition: Sendable {
 |---|---|
 | 任意 → `.waiting` | 通知「需要你的审批/输入」+ `waitingMessage` |
 | 任意 → `.failed` | 通知「任务失败」 |
-| `.running` → `.completed` | 通知「任务完成」(可选,默认开) |
+| `.running` → `.completed` | 通知「任务完成」(可选,默认关,减少噪音) |
 | 首次出现(oldStatus == nil) | 不通知(避免 app 启动时快照轰炸) |
 
 ---
@@ -82,6 +90,12 @@ public struct AgentTask: Identifiable, Hashable, Codable, Sendable {
     public var updatedAt: Date
     public let taskURL: String
     public var waitingMessage: String?
+    public var identity: TaskIdentity  // (source, id),跨 agent 全局唯一
+}
+
+public struct TaskIdentity: Hashable, Codable, Sendable {
+    public let source: String
+    public let id: String
 }
 
 public enum TaskStatus: String, Codable, Sendable {
@@ -109,7 +123,9 @@ public enum APIKeyStatus: Equatable, Sendable {
 - `TaskStore` 没有 `reply` 方法 — v2 再加
 - 没有附件下载
 - 只支持单 Manus 账户
-- `openTaskInBrowser` 由 C 调用 `TaskStore.openTaskInBrowser(id:)`,不是通过 AgentConnector
+- session id 只在单个 source 内唯一。UI 列表、通知、高亮、跳回必须使用
+  `TaskIdentity` / `AgentTask`,不得把裸 `id` 当全局 key
+- `openTaskInBrowser` 由 C 调用 `TaskStore.openTask(_:)`,不是通过 AgentConnector
 
 ---
 
@@ -170,7 +186,7 @@ public enum CursorHooksInstaller {  // 写 ~/.cursor/hooks.json(扁平 entry + �
 ```swift
 /// 所有本地 agent 的注册表 — 设置页按此渲染行(顺序即显示顺序)。
 public enum LocalAgentRegistry {
-    public static let all: [LocalAgentDescriptor]          // 当前: claudeCode, codex, cursor
+    public static let all: [LocalAgentDescriptor]          // 当前: claudeCode, codex, cursor, geminiCLI
     public static func descriptor(for source: String) -> LocalAgentDescriptor?
 }
 
@@ -200,6 +216,10 @@ public struct LocalHooksInstaller: Sendable {
 - **B 侧设置页渲染循环**:`ForEach(LocalAgentRegistry.all, id: \.source)` → 每行用
   `LocalHooksInstaller(descriptor)` 做开关;当前 `SettingsView` 已按此实现,可直接参考
 - 核心侧新增 agent 只改注册表,不会破坏 B 侧代码;设置页自动多一行
+- Gemini CLI 注册项:`source == "gemini-cli"`,写 `~/.gemini/settings.json`,订阅
+  `SessionStart / BeforeAgent / Notification / AfterAgent / SessionEnd`;
+  `ToolPermission` 通知映射 waiting,`AfterAgent` 映射 completed。官方当前没有可靠的
+  failed 事件,因此不推断失败态
 - 三个旧安装器(`ClaudeHooksInstaller` / `CodexHooksInstaller` / `CursorHooksInstaller`)
   是注册表的薄兼容壳,API 与行为不变,新代码不要再用
 - `LocalAgentConnector` 是唯一的本地连接器实现(表驱动);`ClaudeCodeConnector` /
@@ -217,3 +237,5 @@ public struct LocalHooksInstaller: Sendable {
 | 2026-07-29 | v1.3.0 | Cursor 本地连接器:`CursorHooksInstaller`(写 `~/.cursor/hooks.json`,扁平 entry + 顶层 `version: 1`),tasks 新增 `source == "cursor"`;仅订阅 fire-and-forget 事件(sessionStart / beforeSubmitPrompt / stop / sessionEnd),无 waiting 态;`stop.status == "error"` 映射为 failed | `[S] feat(cursor): local hooks connector` |
 | 2026-07-29 | v1.4.0 | **契约冻结(J1/J2)**:新增 `TaskTransition` 结构与 `TaskStore.onTaskTransition` 回调(状态跃迁事件,通知投递用);新增 `TaskStore.jumpToTask(id:)`(app 级激活,失败回退 openTaskInBrowser 行为)。`openTaskInBrowser` 保持不变 | `[S][contract] feat: task transitions + jump-to-task` |
 | 2026-08-03 | v1.5.0 | **契约冻结(J3)**:声明式连接器框架 — 新增 `LocalAgentRegistry` / `LocalAgentDescriptor` / `LocalHooksInstaller`(表驱动:设置行、hook 安装、服务器路由、跳回目标全部由注册表生成);三个旧安装器 enum 降级为兼容壳;三个旧连接器 actor 删除,统一为 `LocalAgentConnector`。`TaskStore` 公开 API 不变 | `[S][contract] feat: declarative local-agent framework` |
+| 2026-08-05 | v1.5.1 | **加法式注册表扩展**:新增 Gemini CLI (`source == "gemini-cli"`,用户配置 `~/.gemini/settings.json`);复用 v1.5.0 描述符/安装器契约,`TaskStore` 公开 API 不变 | `[S][contract] feat(gemini): local hooks connector` |
+| 2026-08-09 | v1.6.0 | **跨 agent 任务身份**:新增 `TaskIdentity(source,id)`、`AgentTask.identity`、source-aware open/jump API 与直接接收 `AgentTask` 的入口;旧裸 id API 保留兼容,遇到歧义拒绝执行;通知/列表/跳回统一使用复合身份 | `[S][contract] fix: source-aware task routing` |


### PR DESCRIPTION
Closes the loop between "an agent needs you" and "you're back in the right window".

### TaskIdentity

A typed `TaskIdentity` replaces bare session IDs across lookups, notification payloads, and jump-back. A session ID is only unique within its own connector — two agents can legally hand us the same string — so anything that routes to a task has to carry the source with it. `TaskTransition.diff` drops its private key struct in favor of it.

### Notifications and jump-back

Clicking a notification expands the island onto that exact task and highlights it; the highlight clears when the panel closes or the task is opened. Notification categories are opt-in per kind, with completions off by default to keep the noise down.

### Bar and Settings

The collapsed bar summarizes multiple concurrent sessions instead of surfacing only the most urgent one. Settings gains search and per-agent grouping. First launch opens a three-step welcome tour that enables connectors and sets notification preferences up front.

### Notes for review

Independent of #16 — both branch from `main` and touch disjoint files. Stacked on top of this one is the smoothness/premium pass, which needs `highlightedTask` and the tour to exist first.

### Test plan

- [x] `swift build` clean
- [x] `swift test` — 128 passing, including new notification-policy, status-summary, and identity tests
- [ ] Manual: trigger a waiting state, click the notification, confirm the panel opens on that task and jumps back to the source app

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Actionable notifications, a first‑run welcome tour, and a multi‑session status summary, with source‑aware task routing. Previously notification clicks opened the task URL in a browser and routing used bare session IDs; now clicks expand the island on that exact task with a highlight, and all routing uses TaskIdentity(source,id). Completion banners are opt‑in and default off to reduce noise.

- Review
  - Notifications: attention-required (waiting/failed) on by default; completions off by default. Authorization is requested only when a category is enabled. Clicks call expand(highlighting:), scroll to the task, and activate the app.
  - Collapsed bar: shows a compact TaskStatusSummary (waiting, failed, running; completed only when nothing active). Highlight styling added to task cards.
  - Settings: adds a Notifications section (with System Settings handoff), search, and per‑agent grouping. The native Settings sheet now hosts the same UI as the gear button.
  - First launch: opens a three‑step Welcome Tour to enable connectors and set notification prefs; finishes by expanding the island.
  - Tests: new coverage for notification policy, summary ordering/ARIA label, and identity resolution.

- Migration
  - Replace bare‑id calls with source‑aware or task‑based APIs to avoid ambiguity:
    - Prefer jumpToTask(_ task) or jumpToTask(source:id:) and openTask(_:) or openTaskInBrowser(source:id:).
    - openTaskInBrowser(id:) and jumpToTask(id:) now no‑op if the id is not unique across sources.

<sup>Written for commit 4980f32a1ff2d5a40c2cfb48217a19466dc50fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sheepxux/Dev-Island/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

